### PR TITLE
openapi schema: Algorithm manifest url needs type

### DIFF
--- a/main/schema/components/algorithm.py
+++ b/main/schema/components/algorithm.py
@@ -74,6 +74,7 @@ algorithm_manifest = {
     'properties': {
         manifest_fields.url: {
             'description': 'Name of algorithm manifest (.yaml) file',
+            'type': 'string',
         }
     },
 }


### PR DESCRIPTION
When I was generating R bindings, this missing type made it so that the `AlgorithmManifest` model couldn't deserialize from JSON properly. I think this is the only place to update?

In other words, `https://www.tatorapp.com/schema` needs to give 
```yaml
    AlgorithmManifest:
      type: object
      properties:
        url:
          description: Name of algorithm manifest (.yaml) file
          type: string # <- This is missing currently
```