### PR TITLE
Switch to playwright from selenium

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
         command: make test
     - run:
         name: Front end tests
-        command: pytest test --host=http://$TATOR_UNIT_TEST_HOST_IP --username=admin --password=admin --screenshots $HOME -s
+        command: pytest test --base-url=http://$TATOR_UNIT_TEST_HOST_IP --browser=chromium --username=admin --password=admin --videos=$HOME -s
     - run:
         name: Copy test directories
         command: cp -r scripts/packages/tator-py/test ./tatorpy_test && cp -r scripts/packages/tator-py/examples .

--- a/install.sh
+++ b/install.sh
@@ -123,7 +123,7 @@ kubectl delete pod sleepy
 echo "Installing pip packages."
 pip3 install --upgrade pip
 pip3 install setuptools
-pip3 install /tmp/*.whl pandas opencv-python pytest pyyaml playwright
+pip3 install /tmp/*.whl pandas opencv-python pytest pyyaml playwright pytest-playwright
 playwright install
 
 # Install tator.

--- a/install.sh
+++ b/install.sh
@@ -17,8 +17,12 @@ sudo snap install microk8s --classic --channel=1.19/stable
 # Install apt packages.
 sudo apt-get update \
     && sudo -E apt-get -yq --no-install-suggests --no-install-recommends install \
-    iproute2 net-tools gzip wget unzip jq ffmpeg python3 python3-pip build-essential \
-    chromium-chromedriver
+    iproute2 net-tools gzip wget unzip jq ffmpeg python3 python3-pip build-essential
+
+# Install Chrome for front end testing.
+echo "Installing Chrome."
+wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+sudo apt install ./google-chrome-stable_current_amd64.deb
 
 # Get IP address if it is not set explicitly.
 # Credit to https://serverfault.com/a/1019371
@@ -119,7 +123,8 @@ kubectl delete pod sleepy
 echo "Installing pip packages."
 pip3 install --upgrade pip
 pip3 install setuptools
-pip3 install /tmp/*.whl pandas opencv-python pytest pyyaml selenium
+pip3 install /tmp/*.whl pandas opencv-python pytest pyyaml playwright
+playwright install
 
 # Install tator.
 echo "Installing tator."

--- a/main/static/js/annotation/entity-selector.js
+++ b/main/static/js/annotation/entity-selector.js
@@ -27,6 +27,7 @@ class EntitySelector extends TatorElement {
 
     const details = document.createElement("details");
     details.setAttribute("class", "position-relative");
+    details.setAttribute("id", "current-index");
     controls.appendChild(details);
 
     const summary = document.createElement("summary");

--- a/test/_common.py
+++ b/test/_common.py
@@ -1,14 +1,20 @@
 import os
 
-class ScreenshotSaver:
-    def __init__(self, browser, directory):
-        self._dir = directory
-        self._browser = browser
-        self._count = 0
+def get_video_path(page):
+    """ Gets a page with video name set to the current test.
+    """
+    dir_name = os.path.dirname(page.video.path())
+    test_name = os.getenv('PYTEST_CURRENT_TEST')
+    test_name = test_name.replace('/', '__').replace('.py::', '__').split('[')[0]
+    file_name = f"{test_name}.webm"
+    path = os.path.join(dir_name, file_name)
+    return path
 
-    def save_screenshot(self, description):
-        fname = f"{self._count:02d}_{description.lower().replace(' ', '_')}.png"
-        out = os.path.join(self._dir, fname)
-        self._browser.save_screenshot(out)
-        self._count += 1
-        
+def print_page_error(err):
+    print("--------------------------------")
+    print("Got page error:")
+    print(f"Message: {err.message}")
+    print(f"Name: {err.name}")
+    print(f"Stack: {err.stack}")
+    print("--------------------------------")
+

--- a/test/_common.py
+++ b/test/_common.py
@@ -1,58 +1,5 @@
 import os
 
-from selenium.common.exceptions import NoSuchElementException
-from urllib.parse import urlparse, urljoin
-
-class ShadowManager:
-    def __init__(self, browser):
-        self._browser = browser
-
-    def expand_shadow_element(self, element):
-        return self._browser.execute_script('return arguments[0].shadowRoot', element)
-
-    def expand_shadow_hierarchy(self, tags):
-        """ Given a list of shadow element tag names, return the shadow dom of the
-            last element.
-        """
-        shadow_root = self._browser
-        for tag in tags:
-            element = shadow_root.find_element_by_tag_name(tag)
-            shadow_root = self.expand_shadow_element(element)
-        return shadow_root
-
-    def find_shadow_tree_elements(self, dom, by, value, single=False):
-        """ Given description of the element you want to find, searches full shadow tree
-            on the page for any elements that match and returns a list.
-        """
-        elements = []
-        # Try to find the specified element in the dom.
-        elements += dom.find_elements(by, value)
-        # Keep searching in nested shadow doms.
-        all_elements = dom.find_elements_by_tag_name("*")
-        for element in all_elements:
-            shadow = self.expand_shadow_element(element)
-            if shadow:
-                elements += self.find_shadow_tree_elements(shadow, by, value)
-            if single and len(elements) > 0:
-                break
-        return elements
-
-    def find_shadow_tree_element(self, dom, by, value):
-        """ Given description of the element you want to find, searches full shadow tree
-            on the page for that element and returns the first one.
-        """
-        elements = self.find_shadow_tree_elements(dom, by, value, True)
-        if len(elements) > 0:
-            element = elements[0]
-        else:
-            raise NoSuchElementException
-        return element
-
-def go_to_uri(browser, uri):
-    parsed = urlparse(browser.current_url)
-    goto = urljoin(f"{parsed.scheme}://{parsed.netloc}", uri)
-    browser.get(goto)
-
 class ScreenshotSaver:
     def __init__(self, browser, directory):
         self._dir = directory

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,59 +4,22 @@ import time
 import datetime
 import subprocess
 import tarfile
+import shutil
 
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-from selenium.webdriver.common.by import By
 import pytest
 import requests
 
-from ._common import ShadowManager
-from ._common import go_to_uri
-
 def pytest_addoption(parser):
-    parser.addoption('--host', help='Tator host', default='https://adamant.duckdns.org')
     parser.addoption('--username', help='Username for login page.')
     parser.addoption('--password', help='Password for login page.')
     parser.addoption('--screenshots', help='Directory to store screenshots.')
     parser.addoption('--keep', help='Do not delete project when done', action='store_true')
 
 def pytest_generate_tests(metafunc):
-    if 'host' in metafunc.fixturenames:
-          metafunc.parametrize('host', [metafunc.config.getoption('host')])
     if 'username' in metafunc.fixturenames:
           metafunc.parametrize('username', [metafunc.config.getoption('username')])
     if 'password' in metafunc.fixturenames:
           metafunc.parametrize('password', [metafunc.config.getoption('password')])
-
-@pytest.fixture(scope='session')
-def browser(request):
-    """ Headless browser based on Chrome. Session is authenticated by entering
-        username and password. """
-    # Driver must be installed via `sudo apt-get install chromium-chromedriver`
-    print("Setting up browser...")
-    host = request.config.option.host
-    username = request.config.option.username
-    password = request.config.option.password
-    keep = request.config.option.keep
-    options = Options()
-    options.headless = True
-    browser = webdriver.Chrome(options=options)
-    browser.set_window_size(1920, 1080)
-    browser.get(host)
-    time.sleep(1)
-    assert(browser.current_url.endswith('/accounts/login/'))
-    mgr = ShadowManager(browser)
-    username_input = mgr.find_shadow_tree_element(browser, By.ID, 'id_username')
-    password_input = mgr.find_shadow_tree_element(browser, By.ID, 'id_password')
-    continue_button = mgr.find_shadow_tree_element(browser, By.CLASS_NAME, 'btn')
-    username_input.send_keys(username)
-    password_input.send_keys(password)
-    continue_button.click()
-    time.sleep(1)
-    assert(browser.current_url.endswith('/projects/'))
-    yield browser
-    browser.quit()
 
 @pytest.fixture(scope='session')
 def screenshots(request):
@@ -66,48 +29,54 @@ def screenshots(request):
     yield screenshots
 
 @pytest.fixture(scope='session')
-def token(request, browser):
+def authenticated(request, base_url, browser_type, browser_type_launch_args, browser_context_args):
+    """ Yields a persistent logged in context. """
+    username = request.config.option.username
+    password = request.config.option.password
+    context = browser_type.launch_persistent_context("./foobar", **{
+        **browser_type_launch_args,
+        **browser_context_args,
+        "base_url": base_url,
+        "locale": "en-US",
+    })
+    page = context.new_page()
+    page.goto('/')
+    page.wait_for_url('/accounts/login/')
+    page.fill('input[name="username"]', username)
+    page.fill('input[name="password"]', password)
+    page.click('input[type="submit"]')
+    page.wait_for_url('/projects/')
+    yield context
+    context.close()
+    shutil.rmtree("./foobar")
+
+@pytest.fixture(scope='session')
+def token(request, authenticated):
     """ Token obtained via the API Token page. """
     print("Getting token...")
     username = request.config.option.username
     password = request.config.option.password
-    keep = request.config.option.keep
-    go_to_uri(browser, 'token')
-    time.sleep(1)
-    mgr = ShadowManager(browser)
-    t0 = datetime.datetime.now()
-    inputs = mgr.find_shadow_tree_elements(browser, By.TAG_NAME, 'input')
-    print(f"Time to find all input tags: {datetime.datetime.now() - t0}")
-    for element in inputs:
-        if element.get_attribute('type') == 'text':
-            element.send_keys(username)
-        elif element.get_attribute('type') == 'password':
-            element.send_keys(password)
-        elif element.get_attribute('type') == 'submit':
-            button = element
-    button.click()
-    time.sleep(1)
-    t0 = datetime.datetime.now()
-    p_list = mgr.find_shadow_tree_elements(browser, By.TAG_NAME, 'p')
-    print(f"Time to find all p tags: {datetime.datetime.now() - t0}")
-    for p in p_list:
-        token = p.get_attribute('textContent')
-        if len(token) == 40:
-            break
+    page = authenticated.new_page()
+    page.goto('/token')
+    page.fill('input[type="text"]', username)
+    page.fill('input[type="password"]', password)
+    page.click('input[type="submit"]')
+    page.wait_for_selector('text=/^.{40}$/')
+    token = page.text_content('modal-notify p')
+    assert(len(token) == 40)
     yield token
 
 @pytest.fixture(scope='session')
-def project(request, browser, token):
+def project(request, authenticated, base_url, token):
     """ Project created with setup_project.py script, all options enabled. """
     print("Creating test project with setup_project.py...")
-    host = request.config.option.host
     current_dt = datetime.datetime.now()
     dt_str = current_dt.strftime('%Y_%m_%d__%H_%M_%S')
     name = f"test_front_end_{dt_str}"
     cmd = [
         'python3',
         'scripts/packages/tator-py/examples/setup_project.py',
-        '--host', host,
+        '--host', base_url,
         '--token', token,
         '--name', name,
         '--create-state-latest',
@@ -115,24 +84,20 @@ def project(request, browser, token):
         '--create-track-type',
     ]
     subprocess.run(cmd, check=True)
-    go_to_uri(browser, 'projects')
-    
-    time.sleep(1)
-    mgr = ShadowManager(browser)
-    # Find all project summary elements.
-    dashboard = browser.find_element(By.TAG_NAME, 'projects-dashboard')
-    shadow = mgr.expand_shadow_element(dashboard)
-    summaries = mgr.find_shadow_tree_elements(shadow, By.TAG_NAME, 'project-summary')
+
+    page = authenticated.new_page()
+    page.goto('/projects')
+    page.wait_for_selector(f'text="{name}"')
+    summaries = page.query_selector_all('project-summary')
     for summary in reversed(summaries):
-        shadow = mgr.expand_shadow_element(summary)
-        title = mgr.find_shadow_tree_element(shadow, By.TAG_NAME, 'h2')
-        if title.get_attribute('textContent') == name:
-            link = mgr.find_shadow_tree_element(shadow, By.TAG_NAME, 'a')
+        if summary.query_selector('h2').text_content() == name:
+            link = summary.query_selector('a')
             href = link.get_attribute('href')
-            project_id = href.split('/')[-2]
+            project_id = int(href.split('/')[-2])
             break
     yield project_id
 
+"""
 @pytest.fixture(scope='session')
 def video_section(request, browser, project):
     print("Creating video section...")
@@ -252,4 +217,4 @@ def video(request, browser, project, video_section, video_file):
             break
     video = int(media_cards[0].get_attribute('media-id'))
     yield video
-
+"""

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -45,6 +45,7 @@ def authenticated(request, launch_time, base_url, browser_type, browser_type_lau
         "base_url": base_url,
         "record_video_dir": videos,
         "locale": "en-US",
+        "executable_path": "/usr/bin/google-chrome",
     })
     page = context.new_page()
     page.goto('/')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -31,6 +31,7 @@ def screenshots(request):
 @pytest.fixture(scope='session')
 def authenticated(request, base_url, browser_type, browser_type_launch_args, browser_context_args):
     """ Yields a persistent logged in context. """
+    print("Logging in...")
     username = request.config.option.username
     password = request.config.option.password
     context = browser_type.launch_persistent_context("./foobar", **{
@@ -97,49 +98,16 @@ def project(request, authenticated, base_url, token):
             break
     yield project_id
 
-"""
 @pytest.fixture(scope='session')
-def video_section(request, browser, project):
+def video_section(request, authenticated, project):
     print("Creating video section...")
-    go_to_uri(browser, f"{project}/project-detail")
-    time.sleep(1)
-    mgr = ShadowManager(browser)
-    # Click add folder button
-    buttons = mgr.find_shadow_tree_elements(browser, By.TAG_NAME, 'button')
-    found = False
-    for button in buttons:
-        if 'Add folder' in button.get_attribute('textContent'):
-            found = True
-            break
-    assert(found)
-    button.click()
-    time.sleep(1)
-    # Enter name
-    name_dialog = mgr.find_shadow_tree_element(browser, By.TAG_NAME, 'name-dialog')
-    browser.save_screenshot('/home/jon/test.png')
-    shadow = mgr.expand_shadow_element(name_dialog)
-    field = mgr.find_shadow_tree_element(shadow, By.TAG_NAME, 'input')
-    footer = mgr.find_shadow_tree_elements(shadow, By.TAG_NAME, 'button')
-    field.send_keys('Videos')
-    for button in footer:
-        if button.get_attribute('textContent') == 'Save':
-            button.click()
-    time.sleep(1)
-    # Select the new section
-    cards = mgr.find_shadow_tree_elements(browser, By.TAG_NAME, 'section-card')
-    found = False
-    for card in cards:
-        shadow = mgr.expand_shadow_element(card)
-        h2 = mgr.find_shadow_tree_element(shadow, By.TAG_NAME, 'h2')
-        if h2.get_attribute('textContent') == 'Videos':
-            found = True
-            card.click()
-            break
-    assert(found)
-    time.sleep(1)
-    # Get section ID from URL
-    url = browser.current_url
-    section = int(url.split('=')[-1])
+    page = authenticated.new_page()
+    page.goto(f'{project}/project-detail')
+    page.click('text="Add folder"')
+    page.fill('name-dialog input', 'Videos')
+    page.click('text="Save"')
+    page.click('text="Videos"')
+    section = int(page.url.split('=')[-1])
     yield section
 
 @pytest.fixture(scope='session')
@@ -183,6 +151,7 @@ def video_file(request):
                         f.write(chunk)
     yield out_path
 
+"""
 @pytest.fixture(scope='session')
 def video(request, browser, project, video_section, video_file):
     print("Uploading a video...")

--- a/test/simple.py
+++ b/test/simple.py
@@ -1,7 +1,7 @@
 from playwright.sync_api import sync_playwright
 
 with sync_playwright() as p:
-    browser = p.chromium.launch()
+    browser = p.chromium.launch(executable_path='/usr/bin/google-chrome')
     page = browser.new_page()
     page.goto('http://tatordemo.duckdns.org/2146/annotation/437900')
     page.on("pageerror", lambda err: print(err.message))

--- a/test/simple.py
+++ b/test/simple.py
@@ -1,0 +1,13 @@
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page()
+    page.goto('http://tatordemo.duckdns.org/2146/annotation/437900')
+    page.on("pageerror", lambda err: print(err.message))
+    page.fill('input[name="username"]', 'jon')
+    page.fill('input[name="password"]', 'yomp2HOOK7sop-asdf')
+    page.click('input[type="submit"]')
+    page.wait_for_timeout(10000)
+    page.screenshot(path='/home/jon/test.png')
+    browser.close()

--- a/test/test_annotation.py
+++ b/test/test_annotation.py
@@ -27,11 +27,14 @@ def test_annotation(authenticated, project, video):
         page.mouse.down()
         page.mouse.move(x + width, y + height)
         page.mouse.up()
+        page.wait_for_selector('save-dialog.is-open')
         save_dialog = page.query_selector('save-dialog.is-open')
         enum_input = save_dialog.query_selector('enum-input[name="Test Enum"]')
         enum_input.query_selector('select').select_option(enum_value)
         save_dialog.query_selector('text="Save"').click()
-        page.wait_for_timeout(500)
+        light = page.query_selector('#tator-success-light')
+        light.wait_for_element_state('visible')
+        light.wait_for_element_state('hidden')
     # Move boxes
     print("Moving boxes...")
     for idx, (start, enum_value) in enumerate(box_info):
@@ -39,22 +42,28 @@ def test_annotation(authenticated, project, video):
         x += canvas_center_x
         y += canvas_center_y
         page.mouse.click(x+50, y+50)
-        page.wait_for_timeout(500)
+        selector = page.query_selector('entity-selector:visible')
+        selector.wait_for_selector(f'#current-index :text("{idx+1}")')
         page.mouse.move(x+50, y+50)
         page.mouse.down()
         page.mouse.move(x, y)
         page.mouse.up()
-        page.wait_for_timeout(500)
+        light = page.query_selector('#tator-success-light')
+        light.wait_for_element_state('visible')
+        light.wait_for_element_state('hidden')
     # Resize boxes
     print("Resizing boxes...")
     for idx, (start, enum_value) in enumerate(box_info):
         x, y = start
         x += canvas_center_x
         y += canvas_center_y
-        page.mouse.move(x+45, y+45)
         page.mouse.click(x+45, y+45)
-        page.wait_for_timeout(500)
+        selector = page.query_selector('entity-selector:visible')
+        selector.wait_for_selector(f'#current-index :text("{idx+1}")')
+        page.mouse.move(x+45, y+45)
         page.mouse.down()
         page.mouse.move(x+95, y+95)
         page.mouse.up()
-        page.wait_for_timeout(500)
+        light = page.query_selector('#tator-success-light')
+        light.wait_for_element_state('visible')
+        light.wait_for_element_state('hidden')

--- a/test/test_annotation.py
+++ b/test/test_annotation.py
@@ -27,8 +27,9 @@ def test_annotation(authenticated, project, video):
         page.mouse.down()
         page.mouse.move(x + width, y + height)
         page.mouse.up()
-        save_dialog = page.query_selector('save-dialog:visible')
-        save_dialog.query_selector('select').select_option(enum_value)
+        save_dialog = page.query_selector('save-dialog.is-open')
+        enum_input = save_dialog.query_selector('enum-input[name="Test Enum"]')
+        enum_input.query_selector('select').select_option(enum_value)
         save_dialog.query_selector('text="Save"').click()
     """
     # Move boxes

--- a/test/test_annotation.py
+++ b/test/test_annotation.py
@@ -1,16 +1,9 @@
 import os
 import time
 
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.action_chains import ActionChains
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support.ui import Select
-
-from ._common import go_to_uri
-from ._common import ShadowManager
-from ._common import ScreenshotSaver
-
-def test_annotation(browser, screenshots, project, video):
+def test_annotation(authenticated, screenshots, project):#, video):
+    pass
+    """
     print("Going to annotation view...")
     save_dir = os.path.join(screenshots, "annotation")
     os.makedirs(save_dir, exist_ok=True)
@@ -86,6 +79,4 @@ def test_annotation(browser, screenshots, project, video):
             .click()\
             .perform()
     saver.save_screenshot('resized_boxes')
-
-        
-    
+    """

--- a/test/test_annotation.py
+++ b/test/test_annotation.py
@@ -31,39 +31,30 @@ def test_annotation(authenticated, project, video):
         enum_input = save_dialog.query_selector('enum-input[name="Test Enum"]')
         enum_input.query_selector('select').select_option(enum_value)
         save_dialog.query_selector('text="Save"').click()
-    """
+        page.wait_for_timeout(500)
     # Move boxes
-    print("Moving and resizing boxes...")
+    print("Moving boxes...")
     for idx, (start, enum_value) in enumerate(box_info):
-        left, top = start
-        ActionChains(browser)\
-            .move_to_element(canvas)\
-            .move_by_offset(left+50, top+50)\
-            .click()\
-            .pause(1)\
-            .click_and_hold()\
-            .move_by_offset(-50, -50)\
-            .release()\
-            .pause(1)\
-            .move_by_offset(0, 100)\
-            .click()\
-            .perform()
-    saver.save_screenshot('moved_boxes')
+        x, y = start
+        x += canvas_center_x
+        y += canvas_center_y
+        page.mouse.click(x+50, y+50)
+        page.wait_for_timeout(500)
+        page.mouse.move(x+50, y+50)
+        page.mouse.down()
+        page.mouse.move(x, y)
+        page.mouse.up()
+        page.wait_for_timeout(500)
     # Resize boxes
+    print("Resizing boxes...")
     for idx, (start, enum_value) in enumerate(box_info):
-        left, top = start
-        ActionChains(browser)\
-            .move_to_element(canvas)\
-            .move_by_offset(left, top)\
-            .click()\
-            .pause(1)\
-            .move_by_offset(45, 45)\
-            .click_and_hold()\
-            .move_by_offset(50, 50)\
-            .release()\
-            .pause(1)\
-            .move_by_offset(0, 100)\
-            .click()\
-            .perform()
-    saver.save_screenshot('resized_boxes')
-    """
+        x, y = start
+        x += canvas_center_x
+        y += canvas_center_y
+        page.mouse.move(x+45, y+45)
+        page.mouse.click(x+45, y+45)
+        page.wait_for_timeout(500)
+        page.mouse.down()
+        page.mouse.move(x+95, y+95)
+        page.mouse.up()
+        page.wait_for_timeout(500)


### PR DESCRIPTION
In light of poor support for shadow DOM in selenium and non-responsiveness of event listeners in cypress, this switches the unit testing framework to playwright which has excellent shadow DOM support, a python interface, videos, screenshots, manual mouse movements, multi-file uploads, downloads, and a code-gen capability using UI actions as input.