### PR TITLE
Checks default value is a valid enum choice before sending

### DIFF
--- a/ui/src/js/project-settings/attributes/attributes-form.js
+++ b/ui/src/js/project-settings/attributes/attributes-form.js
@@ -947,7 +947,14 @@ export class AttributesForm extends TatorElement {
       // 
       if (dtype === "enum") {
 
-        if ((this.isClone || this._dtype.changed() || this._enumDefault.changed || this._choices.changed() || this._labels.changed()) && this._enumDefault.value !== null) { //&& this._enumDefault.value !== ""
+        if (
+          (this.isClone
+          || this._dtype.changed()
+          || this._enumDefault.changed
+          || this._choices.changed()
+          || this._labels.changed())
+          && this._choices.getValue().includes(this._enumDefault.value)
+        ) {
           formData["default"] = this._enumDefault.value;
         }
 


### PR DESCRIPTION
Previously, if the project settings UI was used to edit an enum attribute, it would fail to save after adding a choice if no default value was specified. Now, the UI checks that the default value it is attempting to send is a valid choice and only includes it in the update if it is a valid choice.

Closes #780.