### PR TITLE
Limits attribute type mutation

### DIFF
--- a/main/rest/attribute_type.py
+++ b/main/rest/attribute_type.py
@@ -95,7 +95,7 @@ class AttributeTypeListAPI(BaseListView):
         types that have an attribute with the given name for bulk mutation.
         """
         project = target_entity_type.project
-        for entity_type, entity in ENTITY_TYPES.values():
+        for entity_type, _ in ENTITY_TYPES.values():
             for instance in entity_type.objects.filter(project=project):
                 # Ignore the given entity type
                 if instance.id == target_entity_type.id:
@@ -120,6 +120,9 @@ class AttributeTypeListAPI(BaseListView):
         old_dtype = None
         old_attribute_type = None
         new_attribute_type = params["new_attribute_type"]
+
+        # This is a temporary limit until ES is removed
+        max_instances = params.get("max_instances", 100000)
         new_name = new_attribute_type["name"]
         attribute_renamed = old_name != new_name
 
@@ -177,7 +180,7 @@ class AttributeTypeListAPI(BaseListView):
                         f"Currently, this is not allowed from the UI."
                     )
                 cls._check_attribute_type(new_attribute_type)
-                ts.check_mutation(entity_type, old_name, new_attribute_type)
+                ts.check_mutation(entity_type, old_name, new_attribute_type, max_instances)
 
             # List of success messages to return
             messages = []

--- a/main/rest/attribute_type.py
+++ b/main/rest/attribute_type.py
@@ -180,7 +180,20 @@ class AttributeTypeListAPI(BaseListView):
                         f"Currently, this is not allowed from the UI."
                     )
                 cls._check_attribute_type(new_attribute_type)
-                ts.check_mutation(entity_type, old_name, new_attribute_type, max_instances)
+                ts.check_mutation(entity_type, old_name, new_attribute_type)
+
+                # TODO Remove this check once ES has been removed
+                if obj_qs.filter(project=entity_type.project).count() > max_instances:
+                    type_name = type(entity_type).__name__
+                    name = type_name.replace("Type", "")
+
+                    if name != "Media":
+                        name += "s"
+
+                    raise RuntimeError(
+                        f"Cannot mutate {type_name} with ID {entity_type.id} via the web UI "
+                        f"because it has too many {name}. Contact your Tator admin for assistance."
+                    )
 
             # List of success messages to return
             messages = []

--- a/main/schema/components/attribute_type.py
+++ b/main/schema/components/attribute_type.py
@@ -114,6 +114,7 @@ attribute_type_properties_no_defaults = {
 
 attribute_type_update = {
     "type": "object",
+    "required": ["entity_type", "old_attribute_type_name", "new_attribute_type"],
     "description": "Renames an attribute of a type.",
     "properties": {
         "entity_type": {
@@ -127,6 +128,10 @@ attribute_type_update = {
         "new_attribute_type": {
             'type': 'object',
             'properties': attribute_type_properties_no_defaults,
+        },
+        "max_instances": {
+            "type": "integer",
+            "description": "If specified, the mutation will fail if more instances exist.",
         },
     },
 }

--- a/main/search.py
+++ b/main/search.py
@@ -358,7 +358,7 @@ class TatorSearch:
         attribute_type_uuids[new_name] = attribute_type_uuids.pop(old_name)
         entity_type.attribute_types[replace_idx] = new_attribute_type
 
-    def check_mutation(self, entity_type, name, new_attribute_type, max_instances=None):
+    def check_mutation(self, entity_type, name, new_attribute_type):
         """
         Checks mutation operation and raises if it is invalid. See `mutate_alias` for argument
         description.
@@ -385,15 +385,6 @@ class TatorSearch:
         if new_dtype not in ALLOWED_MUTATIONS[old_dtype]:
             raise RuntimeError(f"Attempted mutation of {name} from {old_dtype} to {new_dtype} is "
                                 "not allowed!")
-
-        # Check that there are not too many documents
-        if max_instances:
-            query = {"query": {"exists": {"field": old_mapping_name}}}
-            if self.count(entity_type.project.pk, query) > max_instances:
-                raise RuntimeError(
-                    f"Cannot mutate {type(entity_type).__name__} ID {entity_type.id} via the web "
-                    f"UI, it has too many instances. Contact your Tator admin for assistance."
-                )
 
         return uuid, replace_idx, old_mapping_name
 

--- a/main/search.py
+++ b/main/search.py
@@ -358,7 +358,7 @@ class TatorSearch:
         attribute_type_uuids[new_name] = attribute_type_uuids.pop(old_name)
         entity_type.attribute_types[replace_idx] = new_attribute_type
 
-    def check_mutation(self, entity_type, name, new_attribute_type):
+    def check_mutation(self, entity_type, name, new_attribute_type, max_instances=None):
         """
         Checks mutation operation and raises if it is invalid. See `mutate_alias` for argument
         description.
@@ -385,6 +385,15 @@ class TatorSearch:
         if new_dtype not in ALLOWED_MUTATIONS[old_dtype]:
             raise RuntimeError(f"Attempted mutation of {name} from {old_dtype} to {new_dtype} is "
                                 "not allowed!")
+
+        # Check that there are not too many documents
+        if max_instances:
+            query = {"query": {"exists": {"field": old_mapping_name}}}
+            if self.count(entity_type.project.pk, query) > max_instances:
+                raise RuntimeError(
+                    f"Cannot mutate {type(entity_type).__name__} ID {entity_type.id} via the web "
+                    f"UI, it has too many instances. Contact your Tator admin for assistance."
+                )
 
         return uuid, replace_idx, old_mapping_name
 


### PR DESCRIPTION
This adds the `max_instances` field for the attribute type endpoint, which puts an upper limit on the number of affected instances for a valid attribute type mutation.