### PR TITLE
Add support for proxied buckets

### DIFF
--- a/helm/tator/templates/_tatorEnv.tpl
+++ b/helm/tator/templates/_tatorEnv.tpl
@@ -1,6 +1,6 @@
 {{- define "tatorEnv.template" }}
 - name: DJANGO_SECRET_KEY
-  valueFrom:
+ valueFrom:
     secretKeyRef:
       name: tator-secrets
       key: djangoSecretKey
@@ -64,6 +64,8 @@
   value: {{ .Values.objectStorageAccessKey }}
 - name: OBJECT_STORAGE_SECRET_KEY
   value: {{ .Values.objectStorageSecretKey }}
+- name: OBJECT_STORAGE_EXTERNAL_HOST
+  value: {{ .Values.objectStorageProxy }}
 {{- end }}
 {{- if hasKey .Values "uploadBucket" }}
 {{- if .Values.uploadBucket.enabled }}
@@ -77,6 +79,8 @@
   value: {{ .Values.uploadBucket.accessKey }}
 - name: UPLOAD_STORAGE_SECRET_KEY
   value: {{ .Values.uploadBucket.secretKey }}
+- name: UPLOAD_STORAGE_EXTERNAL_HOST
+  value: {{ .Values.uploadBucket.proxy }}
 {{- end }}
 {{- end }}
 {{- if hasKey .Values "backupBucket" }}
@@ -91,6 +95,8 @@
   value: {{ .Values.backupBucket.accessKey }}
 - name: BACKUP_STORAGE_SECRET_KEY
   value: {{ .Values.backupBucket.secretKey }}
+- name: BACKUP_STORAGE_EXTERNAL_HOST
+  value: {{ .Values.backupBucket.proxy }}
 {{- end }}
 {{- end }}
 - name: TATOR_DEBUG

--- a/helm/tator/templates/_tatorEnv.tpl
+++ b/helm/tator/templates/_tatorEnv.tpl
@@ -1,6 +1,6 @@
 {{- define "tatorEnv.template" }}
 - name: DJANGO_SECRET_KEY
- valueFrom:
+  valueFrom:
     secretKeyRef:
       name: tator-secrets
       key: djangoSecretKey
@@ -44,7 +44,7 @@
 - name: OBJECT_STORAGE_HOST
   value: http://tator-minio:9000
 - name: OBJECT_STORAGE_EXTERNAL_HOST
-  value: {{ .Values.domain }}/objects
+  value: {{ ternary "https://" "http://" .Values.requireHttps }}{{ .Values.domain }}/objects
 - name: OBJECT_STORAGE_REGION_NAME
   value: {{ .Values.objectStorageRegionName | default "us-east-2" | quote }}
 - name: BUCKET_NAME
@@ -64,8 +64,10 @@
   value: {{ .Values.objectStorageAccessKey }}
 - name: OBJECT_STORAGE_SECRET_KEY
   value: {{ .Values.objectStorageSecretKey }}
+{{- if hasKey .Values "objectStorageProxy" }}
 - name: OBJECT_STORAGE_EXTERNAL_HOST
   value: {{ .Values.objectStorageProxy }}
+{{- end }}
 {{- end }}
 {{- if hasKey .Values "uploadBucket" }}
 {{- if .Values.uploadBucket.enabled }}
@@ -79,8 +81,10 @@
   value: {{ .Values.uploadBucket.accessKey }}
 - name: UPLOAD_STORAGE_SECRET_KEY
   value: {{ .Values.uploadBucket.secretKey }}
+{{- if hasKey .Values.uploadBucket "proxy" }}
 - name: UPLOAD_STORAGE_EXTERNAL_HOST
   value: {{ .Values.uploadBucket.proxy }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if hasKey .Values "backupBucket" }}
@@ -95,8 +99,10 @@
   value: {{ .Values.backupBucket.accessKey }}
 - name: BACKUP_STORAGE_SECRET_KEY
   value: {{ .Values.backupBucket.secretKey }}
+{{- if hasKey .Values.backupBucket "proxy" }}
 - name: BACKUP_STORAGE_EXTERNAL_HOST
   value: {{ .Values.backupBucket.proxy }}
+{{- end }}
 {{- end }}
 {{- end }}
 - name: TATOR_DEBUG

--- a/main/rest/organization_upload_info.py
+++ b/main/rest/organization_upload_info.py
@@ -42,8 +42,12 @@ class OrganizationUploadInfoAPI(BaseDetailView):
 
         # Replace host if external host is given.
         if tator_store.external_host:
+            external = urlsplit(tator_store.external_host, scheme=PROTO)
             urls = [
-                urlunsplit(urlsplit(url)._replace(netloc=tator_store.external_host, scheme=PROTO))
+                urlunsplit(urlsplit(url)._replace(
+                    netloc=external.netloc + external.path,
+                    scheme=external.scheme
+                ))
                 for url in urls
             ]
 

--- a/main/rest/upload_info.py
+++ b/main/rest/upload_info.py
@@ -83,8 +83,9 @@ class UploadInfoAPI(BaseDetailView):
 
         # Replace host if external host is given.
         if tator_store.external_host and project_obj.bucket is None:
+            external = urlsplit(tator_store.external_host, scheme=PROTO)
             urls = [
-                urlunsplit(urlsplit(url)._replace(netloc=tator_store.external_host, scheme=PROTO))
+                urlunsplit(urlsplit(url)._replace(netloc=external.netloc, scheme=external.scheme))
                 for url in urls
             ]
 

--- a/main/rest/upload_info.py
+++ b/main/rest/upload_info.py
@@ -85,7 +85,10 @@ class UploadInfoAPI(BaseDetailView):
         if tator_store.external_host and project_obj.bucket is None:
             external = urlsplit(tator_store.external_host, scheme=PROTO)
             urls = [
-                urlunsplit(urlsplit(url)._replace(netloc=external.netloc, scheme=external.scheme))
+                urlunsplit(urlsplit(url)._replace(
+                    netloc=external.netloc + external.path,
+                    scheme=external.scheme
+                ))
                 for url in urls
             ]
 

--- a/main/store.py
+++ b/main/store.py
@@ -354,7 +354,8 @@ class MinIOStorage(TatorStorage):
         # Replace host if external host is given.
         if self.external_host:
             parsed = urlsplit(url)
-            parsed = parsed._replace(netloc=self.external_host, scheme=self.proto)
+            external = urlsplit(self.external_host, scheme=self.proto)
+            parsed = parsed._replace(netloc=external.netloc, scheme=external.scheme)
             url = urlunsplit(parsed)
         return url
 

--- a/main/store.py
+++ b/main/store.py
@@ -355,7 +355,7 @@ class MinIOStorage(TatorStorage):
         if self.external_host:
             parsed = urlsplit(url)
             external = urlsplit(self.external_host, scheme=self.proto)
-            parsed = parsed._replace(netloc=external.netloc, scheme=external.scheme)
+            parsed = parsed._replace(netloc=external.netloc + external.path, scheme=external.scheme)
             url = urlunsplit(parsed)
         return url
 


### PR DESCRIPTION
This works simply by replacing the host and protocol with the given proxy URL for all pre-signed URLs. Backend communication is still via the `host` parameter. This was done primarily to facilitate CORS header insertion for OCI buckets.