### PR TITLE
Fixes #1124, merge Dev/assume public authentication

### DIFF
--- a/api/main/rest/_permissions.py
+++ b/api/main/rest/_permissions.py
@@ -167,7 +167,7 @@ class PermalinkPermission(BasePermission):
                     return True
         except Exception as e:
             # This is an untrusted endpoint, so don't leak any exceptions to response if possible
-            logger.error(f"Error {e}")
+            logger.error(f"Error {e}", exc_info=True)
 
         return False
 

--- a/api/main/rest/_permissions.py
+++ b/api/main/rest/_permissions.py
@@ -16,6 +16,8 @@ from ..models import Project
 from ..models import Membership
 from ..models import Organization
 from ..models import Affiliation
+from ..models import User
+from ..models import Media
 from ..models import Algorithm
 from ..kube import TatorTranscode
 from ..kube import TatorAlgorithm
@@ -139,6 +141,35 @@ class ProjectFullControlPermission(ProjectPermissionBase):
         Permission.CAN_TRANSFER,
         Permission.CAN_EXECUTE,
     ]
+
+class PermalinkPermission(BasePermission):
+    """
+    1.) Let request through if project has anonymous membership
+    2.) Let request through if requesting user any membership.
+    Note: Because the lowest level of access allows READ the existence check for membership is sufficient.
+    """
+    def has_permission(self, request, view):
+        try:
+            media_id = view.kwargs['id']
+            m = Media.objects.filter(pk=media_id)
+            if not m.exists():
+                return False # If the media doesn't exist, do not authenticate
+            project = m[0].project
+            # Not all deployments have an anonymous user
+            anonymous_user = User.objects.filter(username='anonymous')
+            if anonymous_user.exists():
+                anonymous_membership = Membership.objects.filter(project=project, user=anonymous_user[0])
+                if anonymous_membership.exists():
+                    return True
+            if not isinstance(request.user, AnonymousUser):
+                user_membership = Membership.objects.filter(project=project, user=request.user)
+                if user_membership.exists():
+                    return True
+        except Exception as e:
+            # This is an untrusted endpoint, so don't leak any exceptions to response if possible
+            logger.error(f"Error {e}")
+
+        return False
 
 class UserPermission(BasePermission):
     """ 1.) Reject all anonymous requests

--- a/api/main/rest/permalink.py
+++ b/api/main/rest/permalink.py
@@ -28,7 +28,7 @@ from ..schema.components import media as media_schema
 from ..store import get_tator_store, get_storage_lookup
 
 from ._base_views import process_exception
-from ._permissions import ProjectTransferPermission
+from ._permissions import PermalinkPermission
 
 import sys
 
@@ -74,7 +74,7 @@ class PermalinkAPI(APIView):
         sub-element.
     """
     schema = PermalinkSchema()
-    permission_classes = [ProjectTransferPermission]
+    permission_classes = [PermalinkPermission]
     lookup_field = 'id'
     http_method_names = ['get', 'patch', 'delete']
 


### PR DESCRIPTION
Resolves the disconnect of public authentication in the permalink endpoint: 

If a project is public
- Access to authenticated anonymous user (e.g. guest account) is granted
- Access to unauthenticated anonymous user (e.g. HTTP get from wget) is granted
- Access to an authenticated tator user (e.g. random user) is granted
- Access to an authenticated tator user with a membership to the project is granted.
If a project is private
- Access to authenticated anonymous user (e.g. guest account) is **not granted**
- Access to unauthenticated anonymous user (e.g. HTTP get from wget) is **not granted**
- Access to an authenticated tator user (e.g. random user) is **not granted**
- Access to an authenticated tator user with a membership to the project is granted.

