### PR TITLE
Better username handling

### DIFF
--- a/api/main/models.py
+++ b/api/main/models.py
@@ -332,6 +332,9 @@ class User(AbstractUser):
         else:
             return f"{self.username}"
 
+    def natural_key(self):
+        return (self.username.lower(),)
+
 @receiver(post_save, sender=User)
 def user_save(sender, instance, created, **kwargs):
     if os.getenv('COGNITO_ENABLED') == 'TRUE':

--- a/api/main/rest/user.py
+++ b/api/main/rest/user.py
@@ -137,6 +137,10 @@ class UserListAPI(BaseListView):
         password = params['password']
         registration_token = params.get('registration_token')
 
+        # Case-insensitive check on username existence
+        if User.objects.filter(username__iexact=username).count() > 0:
+            raise ValueError(f"Username is already taken!")
+
         if registration_token is None:
             # This is an anonymous registration, check to see if this is allowed.
             if settings.ANONYMOUS_REGISTRATION_ENABLED:

--- a/api/main/rest/user.py
+++ b/api/main/rest/user.py
@@ -102,7 +102,7 @@ class UserExistsAPI(BaseDetailView):
         if email is not None:
             users = User.objects.filter(email=email)
         if username is not None:
-            users = User.objects.filter(username=username)
+            users = User.objects.filter(username__iexact=username)
         if elemental_id is not None:
             users = User.objects.filter(elemental_id=elemental_id)
         return users.exists()
@@ -124,7 +124,7 @@ class UserListAPI(BaseListView):
         if email is not None:
             users = User.objects.filter(email=email)
         if username is not None:
-            users = User.objects.filter(username=username)
+            users = User.objects.filter(username__iexact=username)
         if elemental_id is not None:
             users = User.objects.filter(elemental_id=elemental_id)
         return user_serializer_helper(UserSerializerBasic(users, many=True).data, params.get('presigned', None))

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -4530,11 +4530,13 @@ class UsernameTestCase(TatorTransactionTest):
     def test_strip_whitespace_on_creation(self):
         username = "   Hodor     "
         user = create_test_user(username=username)
+        self.client.force_authenticate(user)
         self.assertEqual(user.username, username.strip())
 
     def test_case_insensitive_username(self):
         username = "HoDoR"
         user = create_test_user(username=username)
+        self.client.force_authenticate(user)
 
         # The stored username should match the original capitalization
         self.assertEqual(user.username, username)

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -4520,3 +4520,28 @@ class JobClusterTestCase(TatorTransactionTest):
         assertResponse(self, response, status.HTTP_403_FORBIDDEN)
         affiliation.permission = old_permission
         affiliation.save()
+
+
+class UsernameTestCase(TatorTransactionTest):
+    def setUp(self):
+        self.list_uri = "Users"
+        self.detail_uri = "User"
+
+    def test_strip_whitespace_on_creation(self):
+        username = "   Hodor     "
+        user = create_test_user(username=username)
+        self.assertEqual(user.username == username.strip())
+
+    def test_case_insensitive_username(self):
+        username = "HoDoR"
+        user = create_test_user(username=username)
+
+        # The stored username should match the original capitalization
+        self.assertEqual(user.username == username)
+
+        for name in ["hodor", "HODOR", "hOdOr"]:
+            url = f"/rest/{self.list_uri}?username={name}"
+            response = self.client.get(url)
+            assertResponse(self, response, status.HTTP_200_OK)
+            self.assertEqual(len(response.data), 1)
+            self.assertEqual(response.data[0]["username"], username)

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -4530,7 +4530,8 @@ class UsernameTestCase(TatorTransactionTest):
     def test_strip_whitespace_on_creation(self):
         username = "   Hodor     "
         user = create_test_user(username=username)
-        self.client.force_authenticate(user)
+
+        # The stored username should not have surrounding whitespace
         self.assertEqual(user.username, username.strip())
 
     def test_case_insensitive_username(self):
@@ -4541,7 +4542,7 @@ class UsernameTestCase(TatorTransactionTest):
         # The stored username should match the original capitalization
         self.assertEqual(user.username, username)
 
-        for name in ["hodor", "HODOR", "hOdOr"]:
+        for name in ["HoDoR", "hodor", "HODOR", "hOdOr"]:
             url = f"/rest/{self.list_uri}?username={name}"
             response = self.client.get(url)
             assertResponse(self, response, status.HTTP_200_OK)

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -4530,14 +4530,14 @@ class UsernameTestCase(TatorTransactionTest):
     def test_strip_whitespace_on_creation(self):
         username = "   Hodor     "
         user = create_test_user(username=username)
-        self.assertEqual(user.username == username.strip())
+        self.assertEqual(user.username, username.strip())
 
     def test_case_insensitive_username(self):
         username = "HoDoR"
         user = create_test_user(username=username)
 
         # The stored username should match the original capitalization
-        self.assertEqual(user.username == username)
+        self.assertEqual(user.username, username)
 
         for name in ["hodor", "HODOR", "hOdOr"]:
             url = f"/rest/{self.list_uri}?username={name}"

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -4534,7 +4534,7 @@ class UsernameTestCase(TatorTransactionTest):
         # The stored username should not have surrounding whitespace
         self.assertEqual(user.username, username.strip())
 
-    def test_case_insensitive_username(self):
+    def test_list_case_insensitive_username(self):
         username = "HoDoR"
         user = create_test_user(username=username)
         self.client.force_authenticate(user)
@@ -4548,3 +4548,17 @@ class UsernameTestCase(TatorTransactionTest):
             assertResponse(self, response, status.HTTP_200_OK)
             self.assertEqual(len(response.data), 1)
             self.assertEqual(response.data[0]["username"], username)
+
+    def test_create_case_insensitive_username(self):
+        username = "TYRION"
+        user = create_test_user(username=username)
+        user_spec = {
+            'username': username.lower(),
+            'first_name': "Tyrion",
+            'last_name': "Lannister",
+            'email': "tl@cvisionai.com",
+            'password': "idrinkandiknowthings",
+        }
+        url = f"/rest/{self.list_uri}"
+        response = self.client.post(url, user_spec, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/ui/src/js/registration/registration-page.js
+++ b/ui/src/js/registration/registration-page.js
@@ -189,7 +189,7 @@ export class RegistrationPage extends TatorElement {
     if (username.length == 0) {
       this._valid = false;
     } else {
-      return fetch(`/rest/User/Exists?username=${username}`, {
+      return fetch(`/rest/User/Exists?username=${encodeURIComponent(username)}`, {
         method: "GET",
         credentials: "same-origin",
         headers: {


### PR DESCRIPTION
Strips leading and trailing whitespace on creation, uses case-insensitive matching for login/search.

Closes #1113.