### PR TITLE
Makes git diff operate explicitly on a path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
     - run:
         name: Install Tator
         command: |
-          ssh lightsail 'export DOMAIN_ALIAS='"'localhost'"';cd tator && ./install.sh';
+          ssh lightsail 'export DOMAIN_ALIAS='"'localhost'"'; cd tator && sudo snap refresh core && sudo snap install snapd && ./install.sh';
     - run:
         name: Set public IP as primary domain
         command: |

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ dashboard-token:
 # GIT-based diff for image generation
 # Available for tator-image, change dep to ".token/tator_online_$(GIT_VERSION)"
 # Will cause a rebuild on any dirty working tree OR if the image has been built with a token generated
-ifeq ($(shell git diff api | wc -l), 0)
+ifeq ($(shell git diff -- api | wc -l), 0)
 .token/tator_online_$(GIT_VERSION):
 	@echo "No git changes detected"
 	make tator-image

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ ARGO_MANIFEST_URL="https://github.com/argoproj/argo-workflows/releases/download/
 
 # Install snaps.
 sudo snap install helm --classic
-sudo snap install microk8s --classic --channel=1.22/stable
+sudo snap install microk8s --classic --channel=1.26/stable
 sudo snap install yq
 
 # Install apt packages.


### PR DESCRIPTION
This was a bigger problem when we had `main` there and not `api`, but if anyone created a branch named `api`, it would cause the problem to resurface. The arguments for `git diff` look like this:

```
git diff [<options>] [<commit>] [--] [<path>...]
```

Adding the `--` before the path makes it unambiguous.