### PR TITLE
Upgrade pgvector to latest version

### DIFF
--- a/api/main/schema/components/attribute_type.py
+++ b/api/main/schema/components/attribute_type.py
@@ -73,6 +73,7 @@ attribute_type_properties = {
         "description": "Number of elements for `float_array` dtype.",
         "type": "integer",
         "minimum": 1,
+        "maximum": 2000,
     },
     "style": {
         "description": "Available options: disabled|long_string|start_frame|end_frame|start_frame_check|end_frame_check   "

--- a/containers/postgis/Dockerfile
+++ b/containers/postgis/Dockerfile
@@ -7,7 +7,7 @@ RUN sed -i "s;http://archive.ubuntu.com/ubuntu/;${APT_REPO_HOST};" /etc/apt/sour
 WORKDIR /work
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential git ca-certificates postgresql-server-dev-14 cron && rm -rf /var/lib/apt/lists
-RUN git clone --branch v0.2.7 https://github.com/pgvector/pgvector.git
+RUN git clone --branch v0.4.4 https://github.com/pgvector/pgvector.git
 WORKDIR /work/pgvector
 RUN make
 RUN make install

--- a/containers/tator/requirements.txt
+++ b/containers/tator/requirements.txt
@@ -22,7 +22,7 @@ markdown==3.3.6
 minio==7.1.5
 oci==2.89.0
 okta-jwt-verifier==0.2.3
-pgvector==0.1.6
+pgvector==0.1.8
 pillow==9.5.0
 pillow-avif-plugin==1.2.2
 pillow-heif==0.11.1


### PR DESCRIPTION
This requires running the following commands, after upgrading, to ensure all indices are up to snuff:

`$> make django-shell`

In the shell:
```
from main.util import *
upgrade_vector_db()
```