### PR TITLE
Fixes js warning

### DIFF
--- a/ui/src/js/analytics/collections/store.js
+++ b/ui/src/js/analytics/collections/store.js
@@ -1,4 +1,4 @@
-import create from "zustand/vanilla";
+import { create } from "zustand/vanilla";
 import { subscribeWithSelector } from "zustand/middleware";
 import { getApi } from "../../../../../scripts/packages/tator-js/pkg/src/index.js";
 

--- a/ui/src/js/analytics/corrections/store.js
+++ b/ui/src/js/analytics/corrections/store.js
@@ -1,4 +1,4 @@
-import create from "zustand/vanilla";
+import { create } from "zustand/vanilla";
 import { subscribeWithSelector } from "zustand/middleware";
 import { getApi } from "../../../../../scripts/packages/tator-js/pkg/src/index.js";
 

--- a/ui/src/js/analytics/dashboards/dashboard-store.js
+++ b/ui/src/js/analytics/dashboards/dashboard-store.js
@@ -1,4 +1,4 @@
-import create from "zustand/vanilla";
+import { create } from "zustand/vanilla";
 import { subscribeWithSelector } from "zustand/middleware";
 import { getApi } from "../../../../../scripts/packages/tator-js/pkg/src/index.js";
 

--- a/ui/src/js/analytics/dashboards/store.js
+++ b/ui/src/js/analytics/dashboards/store.js
@@ -1,4 +1,4 @@
-import create from "zustand/vanilla";
+import { create } from "zustand/vanilla";
 import { subscribeWithSelector } from "zustand/middleware";
 import { getApi } from "../../../../../scripts/packages/tator-js/pkg/src/index.js";
 

--- a/ui/src/js/analytics/files/store.js
+++ b/ui/src/js/analytics/files/store.js
@@ -1,4 +1,4 @@
-import create from "zustand/vanilla";
+import { create } from "zustand/vanilla";
 import { subscribeWithSelector } from "zustand/middleware";
 import { getApi } from "../../../../../scripts/packages/tator-js/pkg/src/index.js";
 

--- a/ui/src/js/analytics/localizations/store.js
+++ b/ui/src/js/analytics/localizations/store.js
@@ -1,4 +1,4 @@
-import create from "zustand/vanilla";
+import { create } from "zustand/vanilla";
 import { subscribeWithSelector } from "zustand/middleware";
 import { getApi } from "../../../../../scripts/packages/tator-js/pkg/src/index.js";
 

--- a/ui/src/js/analytics/portal/store.js
+++ b/ui/src/js/analytics/portal/store.js
@@ -1,4 +1,4 @@
-import create from "zustand/vanilla";
+import { create } from "zustand/vanilla";
 import { subscribeWithSelector } from "zustand/middleware";
 import { getApi } from "../../../../../scripts/packages/tator-js/pkg/src/index.js";
 

--- a/ui/src/js/annotation/store.js
+++ b/ui/src/js/annotation/store.js
@@ -1,4 +1,4 @@
-import create from "zustand/vanilla";
+import { create } from "zustand/vanilla";
 import { subscribeWithSelector } from "zustand/middleware";
 import { getApi } from "../../../../scripts/packages/tator-js/pkg/src/index.js";
 

--- a/ui/src/js/organization-settings/store.js
+++ b/ui/src/js/organization-settings/store.js
@@ -1,4 +1,4 @@
-import create from "zustand/vanilla";
+import { create } from "zustand/vanilla";
 import { subscribeWithSelector, devtools } from "zustand/middleware";
 import {
   ApiClient,

--- a/ui/src/js/organizations/store.js
+++ b/ui/src/js/organizations/store.js
@@ -1,4 +1,4 @@
-import create from "zustand/vanilla";
+import { create } from "zustand/vanilla";
 import { subscribeWithSelector } from "zustand/middleware";
 import { getApi } from "../../../../scripts/packages/tator-js/pkg/src/index.js";
 

--- a/ui/src/js/project-detail/store.js
+++ b/ui/src/js/project-detail/store.js
@@ -1,4 +1,4 @@
-import create from "zustand/vanilla";
+import { create } from "zustand/vanilla";
 import { subscribeWithSelector } from "zustand/middleware";
 import { getApi } from "../../../../scripts/packages/tator-js/pkg/src/index.js";
 

--- a/ui/src/js/project-settings/store.js
+++ b/ui/src/js/project-settings/store.js
@@ -1,4 +1,4 @@
-import create from "zustand/vanilla";
+import { create } from "zustand/vanilla";
 import { subscribeWithSelector, devtools } from "zustand/middleware";
 import { getApi } from "../../../../scripts/packages/tator-js/pkg/src/index.js";
 

--- a/ui/src/js/projects/store.js
+++ b/ui/src/js/projects/store.js
@@ -1,4 +1,4 @@
-import create from "zustand/vanilla";
+import { create } from "zustand/vanilla";
 import { subscribeWithSelector } from "zustand/middleware";
 import { getApi } from "../../../../scripts/packages/tator-js/pkg/src/index.js";
 

--- a/ui/src/js/token/store.js
+++ b/ui/src/js/token/store.js
@@ -1,4 +1,4 @@
-import create from "zustand/vanilla";
+import { create } from "zustand/vanilla";
 import { subscribeWithSelector } from "zustand/middleware";
 import { getApi } from "../../../../scripts/packages/tator-js/pkg/src/index.js";
 


### PR DESCRIPTION
The following deprecation warning is being generated when the UI is built:

```
[DEPRECATED] Default export is deprecated. Instead use import { createStore } from 'zustand/vanilla'.
(anonymous) @ organizations.js:2
```

This fixes the import to not generate that warning anymore.