### PR TITLE
Clean up image coordinates

### DIFF
--- a/ui/src/css/components/_annotation.scss
+++ b/ui/src/css/components/_annotation.scss
@@ -147,7 +147,7 @@ save-dialog {
   transform: scale(0.95);
   transition-duration: 0.25s;
   transition-property: transform, opacity;
-  z-index: 2;
+  z-index: 4;
   &.is-open {
     opacity: 1;
     pointer-events: initial;
@@ -174,7 +174,7 @@ modify-track-dialog {
   transform: scale(0.95);
   transition-duration: 0.25s;
   transition-property: transform, opacity;
-  z-index: 2;
+  z-index: 4;
   &.is-open {
     opacity: 1;
     pointer-events: initial;
@@ -338,6 +338,7 @@ favorite-button {
 }
 
 .annotation__video-player {
+  z-index: 2;
   display: flex;
   flex-direction: column;
   flex-grow: 1;

--- a/ui/src/js/annotation/annotation-page.js
+++ b/ui/src/js/annotation/annotation-page.js
@@ -1381,7 +1381,6 @@ export class AnnotationPage extends TatorPage {
                   requestObj,
                   metaMode
                 );
-                this._makePreview(objDescription, dragInfo, canvasPosition);
               }
             });
 
@@ -1955,7 +1954,6 @@ export class AnnotationPage extends TatorPage {
         requestObj,
         metaMode
       );
-      this._makePreview(objDescription, dragInfo, canvasPosition);
     });
 
     if (typeof canvas.addCreateTrackType !== "undefined") {
@@ -1970,7 +1968,6 @@ export class AnnotationPage extends TatorPage {
       save.classList.remove("is-open");
       this.removeAttribute("has-open-modal");
       document.body.classList.remove("shortcuts-disabled");
-      this._main.removeChild(this._preview);
     }
   }
 
@@ -2020,34 +2017,6 @@ export class AnnotationPage extends TatorPage {
     Object.values(this._saves).forEach((save) => {
       save.metaMode = false;
     });
-  }
-
-  _makePreview(objDescription, dragInfo, canvasPosition) {
-    this._preview = document.createElement("div");
-    this._preview.style.overflow = "hidden";
-    this._preview.style.position = "absolute";
-    const prevTop = Math.min(dragInfo.start.y, dragInfo.end.y);
-    const prevLeft = Math.min(dragInfo.start.x, dragInfo.end.x);
-    this._preview.style.top = canvasPosition.top + prevTop + "px";
-    this._preview.style.left = canvasPosition.left + prevLeft + "px";
-    this._preview.style.width =
-      Math.abs(dragInfo.start.x - dragInfo.end.x) - 6 + "px";
-    this._preview.style.height =
-      Math.abs(dragInfo.start.y - dragInfo.end.y) - 6 + "px";
-    this._preview.style.borderStyle = "solid";
-    this._preview.style.borderWidth = "3px";
-    this._preview.style.borderColor = "white";
-    this._preview.style.zIndex = 2;
-    this._main.appendChild(this._preview);
-
-    const img = new Image();
-    img.src = dragInfo.url;
-    img.style.position = "absolute";
-    img.style.top = -prevTop - 3 + "px";
-    img.style.left = -prevLeft - 3 + "px";
-    img.style.width = canvasPosition.width + "px";
-    img.style.height = canvasPosition.height + "px";
-    this._preview.appendChild(img);
   }
 
   /// Turn on or off ability to edit annotations

--- a/ui/src/js/components/canvas-ctxmenu.js
+++ b/ui/src/js/components/canvas-ctxmenu.js
@@ -70,7 +70,7 @@ export class CanvasContextMenu extends TatorElement {
   }
 
   displayMenu(x, y) {
-    this._div.style.zIndex = 1;
+    this._div.style.zIndex = 2;
     this._div.style.left = x + "px";
     this._div.style.top = y + "px";
     this._div.style.display = "block";


### PR DESCRIPTION
- Fixes image coordinate overlay issue
- Removes costly "toDataURL" which was the culprit in playing games with 4k images
- Now that we have 4k videos; this was worth fixing. There was a decent delay in creating the save modal due to a lack of zIndex awareness. The old method rasterized the 4k image via the DOM and a temporary PNG encoding which was very slow. 
