### PR TITLE
added VAST s3 object store option

### DIFF
--- a/api/main/store.py
+++ b/api/main/store.py
@@ -29,6 +29,7 @@ class ObjectStore(Enum):
     MINIO = "MINIO"
     GCP = "GCP"
     OCI = "OCI"
+    VAST = "VAST"
 
 
 # TODO Deprecated: remove once support for old bucket model is removed
@@ -46,6 +47,7 @@ CLIENT_MAP = {
         config["project_id"], Credentials.from_service_account_info(config)
     ),
     ObjectStore.OCI: None,
+    ObjectStore.VAST: None,
 }
 VALID_STORAGE_CLASSES = {
     "archive_sc": {
@@ -53,12 +55,14 @@ VALID_STORAGE_CLASSES = {
         ObjectStore.MINIO: ["STANDARD"],
         ObjectStore.GCP: ["STANDARD", "COLDLINE"],
         ObjectStore.OCI: ["STANDARD"],
+        ObjectStore.VAST: ["STANDARD"],
     },
     "live_sc": {
         ObjectStore.AWS: ["STANDARD"],
         ObjectStore.MINIO: ["STANDARD"],
         ObjectStore.GCP: ["STANDARD"],
         ObjectStore.OCI: ["STANDARD"],
+        ObjectStore.VAST: ["STANDARD"],
     },
 }
 
@@ -69,12 +73,14 @@ DEFAULT_STORAGE_CLASSES = {
         ObjectStore.MINIO: "STANDARD",
         ObjectStore.GCP: "COLDLINE",
         ObjectStore.OCI: "STANDARD",
+        ObjectStore.VAST: "STANDARD",
     },
     "live_sc": {
         ObjectStore.AWS: "STANDARD",
         ObjectStore.MINIO: "STANDARD",
         ObjectStore.GCP: "STANDARD",
         ObjectStore.OCI: "STANDARD",
+        ObjectStore.VAST: "STANDARD",
     },
 }
 
@@ -83,7 +89,7 @@ def _client_from_config(
     store_type, config, bucket_name, connect_timeout, read_timeout, max_attempts
 ):
     config = deepcopy(config)
-    if store_type in [ObjectStore.AWS, ObjectStore.MINIO]:
+    if store_type in [ObjectStore.AWS, ObjectStore.MINIO, ObjectStore.VAST]:
         config["config"] = Config(
             connect_timeout=connect_timeout,
             read_timeout=read_timeout,
@@ -159,7 +165,9 @@ class TatorStorage(ABC):
             return MinIOStorage(bucket, client, bucket_name, external_host)
         if server is ObjectStore.OCI:
             return OCIStorage(bucket, client, bucket_name, external_host)
-
+        if server is ObjectStore.VAST:
+            return VASTStorage(bucket, client, bucket_name, external_host)
+            
         raise ValueError(f"Server type '{server}' is not supported")
 
     def path_to_key(self, path: str) -> str:
@@ -501,6 +509,15 @@ class S3Storage(MinIOStorage):
             RestoreRequest={"Days": min_exp_days},
         )
 
+
+class VASTStorage(MinIOStorage):
+    def __init__(self, bucket, client, bucket_name, external_host=None):
+        super().__init__(bucket, client, bucket_name, external_host)
+        self._server = ObjectStore.VAST
+        
+    # VAST does not support object tags    
+    def put_media_id_tag(self, path, media_id): return 
+    def _put_archive_tag(self, path): return
 
 class OCIStorage(S3Storage):
     ARCHIVE_PREFIX = "_to_archive"


### PR DESCRIPTION
The above changes allows a user to target a [VAST s3 datastore](https://vastdata.com/datastore) for media storage.

VAST doesn't yet implement the full complement of s3 features, eg object tagging, but it's on their roadmap. Until then this object store type for tator should suffice. We've been using this code edit for over a year and it's worked fine.


Other changes required to actually deploy with VAST:

- in `comopse.yaml` remove/comment-out `minio` and `create_bucket` containers
- in `compose/nginx.conf.template` update `location /objects/ { proxy_pass http://minio:9000/; }` to point to your target VAST s3 bucket

Those changes didn't seem to relevant to this PR however and so are not included.