### PR TITLE
Allow non-pedantic edits and deletes by default

### DIFF
--- a/api/main/rest/localization.py
+++ b/api/main/rest/localization.py
@@ -34,6 +34,8 @@ from ._util import (
 )
 from ._permissions import ProjectEditPermission
 
+import uuid
+
 logger = logging.getLogger(__name__)
 
 LOCALIZATION_PROPERTIES = list(localization_schema["properties"].keys())
@@ -325,6 +327,12 @@ class LocalizationDetailBaseAPI(BaseDetailView):
             raise Http404
         obj = qs[0]
         model_dict = obj.model_dict
+
+        # If this is a really old object, it may not have an elemental_id
+        # but we need to add it for trigger support
+        if obj.elemental_id == None:
+            obj.elemental_id = uuid.uuid4()
+            obj.save()
 
         # Patch common attributes.
         frame = params.get("frame", None)

--- a/api/main/rest/localization.py
+++ b/api/main/rest/localization.py
@@ -407,9 +407,9 @@ class LocalizationDetailBaseAPI(BaseDetailView):
             log_changes(obj, model_dict, obj.project, self.request.user)
         else:
             # Only allow iterative changes, this has to be changing off the last mark in the version
-            if obj.mark != obj.latest_mark:
+            if params["pedantic"] and (obj.mark != obj.latest_mark):
                 raise ValueError(
-                    f"Can not edit prior object {obj.pk}, must only edit latest mark on version."
+                    f"Pedantic mode is enabled. Can not edit prior object {obj.pk}, must only edit latest mark on version."
                     f"Object is mark {obj.mark} of {obj.latest_mark} for {obj.version.name}/{obj.elemental_id}"
                 )
 

--- a/api/main/rest/localization.py
+++ b/api/main/rest/localization.py
@@ -225,13 +225,22 @@ class LocalizationListAPI(BaseListView):
                 # Delete the localizations.
                 bulk_delete_and_log_changes(qs, params["project"], self.request.user)
             else:
-                bulk_update_and_log_changes(
-                    qs,
-                    params["project"],
-                    self.request.user,
-                    update_kwargs={"variant_deleted": True},
-                    new_attributes=None,
-                )
+                if params.get("in_place", 0):
+                    bulk_update_and_log_changes(
+                        qs,
+                        params["project"],
+                        self.request.user,
+                        update_kwargs={"variant_deleted": True},
+                        new_attributes=None,
+                    )
+                else:
+                    objs = []
+                    for original in qs.iterator():
+                        original.pk = None
+                        original.id = None
+                        original.variant_deleted = True
+                        objs.append(original)
+                    Localization.objects.bulk_create(objs)
 
         return {"message": f"Successfully deleted {count} localizations!"}
 

--- a/api/main/rest/localization.py
+++ b/api/main/rest/localization.py
@@ -443,6 +443,9 @@ class LocalizationDetailBaseAPI(BaseDetailView):
         if not qs.exists():
             raise Http404
         obj = qs[0]
+        if obj.elemental_id == None:
+            obj.elemental_id = uuid.uuid4()
+            obj.save()
         elemental_id = obj.elemental_id
         version_id = obj.version.id
         mark = obj.mark

--- a/api/main/rest/localization.py
+++ b/api/main/rest/localization.py
@@ -432,7 +432,13 @@ class LocalizationDetailBaseAPI(BaseDetailView):
         if params["prune"] == 1:
             delete_and_log_changes(obj, obj.project, self.request.user)
         else:
+            if params["pedantic"] and (obj.mark != obj.latest_mark):
+                raise ValueError(
+                    f"Pedantic mode is enabled. Can not edit prior object {obj.pk}, must only edit latest mark on version."
+                    f"Object is mark {obj.mark} of {obj.latest_mark} for {obj.version.name}/{obj.elemental_id}"
+                )
             b = qs[0]
+            b.pk = None
             b.variant_deleted = True
             b.save()
             log_changes(b, b.model_dict, b.project, self.request.user)

--- a/api/main/rest/state.py
+++ b/api/main/rest/state.py
@@ -513,9 +513,9 @@ class StateDetailBaseAPI(BaseDetailView):
             obj.save()
             log_changes(obj, model_dict, obj.project, self.request.user)
         else:
-            if obj.mark != obj.latest_mark:
+            if params["pedantic"] and (obj.mark != obj.latest_mark):
                 raise ValueError(
-                    f"Can not edit prior object {obj.pk}, must only edit latest mark on version."
+                    f"Pedantic mode is enabled. Can not edit prior object {obj.pk}, must only edit latest mark on version."
                     f"Object is mark {obj.mark} of {obj.latest_mark} for {obj.version.name}/{obj.elemental_id}"
                 )
 

--- a/api/main/rest/state.py
+++ b/api/main/rest/state.py
@@ -556,6 +556,12 @@ class StateDetailBaseAPI(BaseDetailView):
             qs = Localization.objects.filter(pk__in=delete_localizations)
             bulk_delete_and_log_changes(qs, project, self.request.user)
         else:
+            if params["pedantic"] and (state.mark != state.latest_mark):
+                raise ValueError(
+                    f"Pedantic mode is enabled. Can not edit prior object {state.pk}, must only edit latest mark on version."
+                    f"Object is mark {state.mark} of {state.latest_mark} for {state.version.name}/{state.elemental_id}"
+                )
+            state.pk = None
             state.variant_deleted = True
             state.save()
             log_changes(state, state.model_dict, state.project, self.request.user)

--- a/api/main/rest/state.py
+++ b/api/main/rest/state.py
@@ -457,6 +457,12 @@ class StateDetailBaseAPI(BaseDetailView):
         obj = qs[0]
         model_dict = obj.model_dict
 
+        # If this is a really old object, it may not have an elemental_id
+        # but we need to add it for trigger support
+        if obj.elemental_id == None:
+            obj.elemental_id = uuid.uuid4()
+            obj.save()
+
         if "frame" in params:
             obj.frame = params["frame"]
 
@@ -546,9 +552,9 @@ class StateDetailBaseAPI(BaseDetailView):
         if not qs.exists():
             raise Http404
         state = qs[0]
-        if obj.elemental_id == None:
-            obj.elemental_id = uuid.uuid4()
-            obj.save()
+        if state.elemental_id == None:
+            state.elemental_id = uuid.uuid4()
+            state.save()
         elemental_id = state.elemental_id
         version_id = state.version.id
         mark = state.mark

--- a/api/main/rest/state.py
+++ b/api/main/rest/state.py
@@ -8,6 +8,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.http import Http404
 import numpy as np
+import uuid
 
 from ..models import State
 from ..models import StateType
@@ -545,6 +546,9 @@ class StateDetailBaseAPI(BaseDetailView):
         if not qs.exists():
             raise Http404
         state = qs[0]
+        if obj.elemental_id == None:
+            obj.elemental_id = uuid.uuid4()
+            obj.save()
         elemental_id = state.elemental_id
         version_id = state.version.id
         mark = state.mark

--- a/api/main/rest/version.py
+++ b/api/main/rest/version.py
@@ -1,6 +1,7 @@
 import logging
 from collections import defaultdict
 from django.db import transaction
+from django.db.models import F
 from django.utils import timezone
 import datetime
 import uuid
@@ -118,10 +119,10 @@ class VersionDetailAPI(BaseDetailView):
 
     def _delete(self, params):
         localization_count = Localization.objects.filter(
-            version=params["id"], deleted=False, variant_deleted=False
+            version=params["id"], deleted=False, variant_deleted=False, mark=F("latest_mark")
         ).count()
         state_count = State.objects.filter(
-            version=params["id"], deleted=False, variant_deleted=False
+            version=params["id"], deleted=False, variant_deleted=False, mark=F("latest_mark")
         ).count()
         if localization_count > 0 or state_count > 0:
             raise Exception(

--- a/api/main/schema/components/localization.py
+++ b/api/main/schema/components/localization.py
@@ -277,7 +277,14 @@ localization_delete_schema = {
             "minimum": 0,
             "maximum": 1,
             "default": 0,
-        }
+        },
+        "pedantic": {
+            "type": "integer",
+            "description": "Set to 1 to enforce that this is the latest mark; else push edits to end of branch.",
+            "minimum": 0,
+            "maximum": 1,
+            "default": 0,
+        },
     },
 }
 localization_bulk_delete_schema = {

--- a/api/main/schema/components/localization.py
+++ b/api/main/schema/components/localization.py
@@ -209,6 +209,13 @@ localization_update = {
             "maximum": 1,
             "default": 0,
         },
+        "pedantic": {
+            "type": "integer",
+            "description": "Set to 1 to enforce that this is the latest mark; else push edits to end of branch.",
+            "minimum": 0,
+            "maximum": 1,
+            "default": 0,
+        },
     },
 }
 

--- a/api/main/schema/components/state.py
+++ b/api/main/schema/components/state.py
@@ -270,7 +270,14 @@ state_delete_schema = {
             "minimum": 0,
             "maximum": 1,
             "default": 0,
-        }
+        },
+        "pedantic": {
+            "type": "integer",
+            "description": "Set to 1 to enforce that this is the latest mark; else push edits to end of branch.",
+            "minimum": 0,
+            "maximum": 1,
+            "default": 0,
+        },
     },
 }
 

--- a/api/main/schema/components/state.py
+++ b/api/main/schema/components/state.py
@@ -162,6 +162,13 @@ state_update = {
             "maximum": 1,
             "default": 0,
         },
+        "pedantic": {
+            "type": "integer",
+            "description": "Set to 1 to enforce that this is the latest mark; else push edits to end of branch.",
+            "minimum": 0,
+            "maximum": 1,
+            "default": 0,
+        },
     },
 }
 

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -1231,9 +1231,11 @@ class AttributeTestMixin:
         )
         assertResponse(self, response, status.HTTP_200_OK)
         # Do this again to test after the attribute object has been created.
-        # This verifies patching non-latest element by serial doesn't work
+        # This verifies patching non-latest element by serial doesn't work (when pedantic)
         response = self.client.patch(
-            f"/rest/{self.detail_uri}/{pk}", {"attributes": {name: test_val}}, format="json"
+            f"/rest/{self.detail_uri}/{pk}",
+            {"attributes": {name: test_val}, "pedantic": 1},
+            format="json",
         )
         if mark_based:
             assertResponse(self, response, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
This corrects a slight API anomaly with the introduction of mark-based versioning. While most of the UI was updated to support fetching via version/elemental_id; a few places were missed resulting in [inability to edit more than once](https://github.com/cvisionai/tator/issues/1572). 

Now by default, edits to a primary key which are not the latest object on the version are allowed; and the new object becomes the latest mark on the version. It should be a goal to enforce pedantic versioning in the future as it prevents a form of user error in SCM systems where eclipses occur on out of order edits.

While investigating this bug, another bug was discovered that very old localizations or states that did not have an elemental_id were unable to be edited via the new database triggers. 

Another bug was discovered investigating this bug with regard to bulk delete operations, which were not honoring the 'in_place' flag properly. This was masked by a tator-py unit test on the changelog.

A future issue should be created to deprecate the ChangeLog or repoint it to track changes to MetadataTypes vs. Metadata itself as the mark-based versioning makes it largely superfluous.
