### PR TITLE
Minor cleanups to localization gallery

### DIFF
--- a/api/main/rest/localization.py
+++ b/api/main/rest/localization.py
@@ -302,11 +302,13 @@ class LocalizationListAPI(BaseListView):
                     original.attributes.update(new_attrs)
                     objs.append(original)
                     origin_datetimes.append(original.created_datetime)
+
                 new_objs = Localization.objects.bulk_create(objs)
 
                 for new_obj, origin_datetime in zip(new_objs, origin_datetimes):
-                    new_obj.created_datetime = origin_datetime
-                    new_obj.save()
+                    found_it = Localization.objects.get(pk=new_obj.pk)
+                    found_it.created_datetime = origin_datetime
+                    found_it.save()
 
         return {"message": f"Successfully updated {count} localizations!"}
 

--- a/api/main/rest/localization.py
+++ b/api/main/rest/localization.py
@@ -453,9 +453,10 @@ class LocalizationDetailBaseAPI(BaseDetailView):
             obj.pk = None
             origin_datetime = obj.created_datetime
             obj.save()
+            found_it = Localization.objects.get(pk=obj.pk)
             # Do a double save to keep original creation time
-            obj.created_datetime = origin_datetime
-            obj.save()
+            found_it.created_datetime = origin_datetime
+            found_it.save()
 
         return {
             "message": f"Localization {obj.elemental_id}@{obj.version.id}/{obj.mark} successfully updated!",

--- a/api/main/rest/state.py
+++ b/api/main/rest/state.py
@@ -423,8 +423,11 @@ class StateListAPI(BaseListView):
                 for p_obj, m2m, origin_datetime in zip(new_objs, many_to_many, origin_datetimes):
                     p_obj.media.set(m2m[0])
                     p_obj.localizations.set(m2m[1])
-                    p_obj.created_datetime = origin_datetime
-                    p_obj.save()
+
+                    # Django doesn't let you fix created_datetime unless you fetch the object again
+                    found_it = State.objects.get(pk=p_obj.pk)
+                    found_it.created_datetime = origin_datetime
+                    found_it.save()
 
         return {"message": f"Successfully updated {count} states!"}
 

--- a/api/main/rest/state.py
+++ b/api/main/rest/state.py
@@ -557,11 +557,12 @@ class StateDetailBaseAPI(BaseDetailView):
             obj.pk = None
             origin_datetime = obj.created_datetime
             obj.save()
+            found_it = State.objects.get(pk=obj.pk)
             # Keep original creation time
-            obj.created_datetime = origin_datetime
-            obj.save()
-            obj.media.set(old_media)
-            obj.localizations.set(old_localizations)
+            found_it.created_datetime = origin_datetime
+            found_it.save()
+            found_it.media.set(old_media)
+            found_it.localizations.set(old_localizations)
 
         return {
             "message": f"State {obj.elemental_id}@{obj.version.id}/{obj.mark} successfully updated!",

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -1317,7 +1317,8 @@ class AttributeTestMixin:
         for pk in many_pks:
             response = self.client.get(f"/rest/{self.detail_uri}/{pk}", format="json")
             assert response.data["attributes"][attribute_name] == null_value
-            datetime_map[response.data["elemental_id"]] = response.data["created_datetime"]
+            if "created_datetime" in response.data:
+                datetime_map[response.data["elemental_id"]] = response.data["created_datetime"]
 
         if hasattr(self.entities[0], "mark") and hasattr(self.entities[0], "elemental_id"):
             version = self.entities[0].version.pk

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -1152,6 +1152,7 @@ class AttributeTestMixin:
         test_vals = [random.random() > 0.5 for _ in range(len(self.entities))]
         for idx, test_val in enumerate(test_vals):
             pk = self.entities[idx].pk
+            print(f"Setting Bool Test to {test_val}")
             response = self.client.patch(
                 f"/rest/{self.detail_uri}/{pk}",
                 {"attributes": {"Bool Test": test_val}},
@@ -1311,9 +1312,12 @@ class AttributeTestMixin:
             format="json",
         )
         assertResponse(self, response, status.HTTP_200_OK)
+        datetime_map = {}
+
         for pk in many_pks:
             response = self.client.get(f"/rest/{self.detail_uri}/{pk}", format="json")
             assert response.data["attributes"][attribute_name] == null_value
+            datetime_map[response.data["elemental_id"]] = response.data["created_datetime"]
 
         if hasattr(self.entities[0], "mark") and hasattr(self.entities[0], "elemental_id"):
             version = self.entities[0].version.pk
@@ -1330,6 +1334,7 @@ class AttributeTestMixin:
                     f"/rest/{self.detail_uri}/{version}/{eid}", format="json"
                 )
                 assert response.data["attributes"][attribute_name] == default_value
+                assert resposne.data["created_datetime"] == datetime_map[eid]
 
             response = self.client.patch(
                 f"/rest/{self.list_uri}/{project.pk}",
@@ -1342,9 +1347,11 @@ class AttributeTestMixin:
                     f"/rest/{self.detail_uri}/{version}/{eid}", format="json"
                 )
                 assert response.data["attributes"][attribute_name] == null_value
+                assert resposne.data["created_datetime"] == datetime_map[eid]
 
     def test_bool_attr(self):
         test_vals = [random.random() > 0.5 for _ in range(len(self.entities))]
+
         # Test setting an invalid bool
         response = self.client.patch(
             f"/rest/{self.detail_uri}/{self.entities[0].pk}",

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -1334,7 +1334,8 @@ class AttributeTestMixin:
                     f"/rest/{self.detail_uri}/{version}/{eid}", format="json"
                 )
                 assert response.data["attributes"][attribute_name] == default_value
-                assert resposne.data["created_datetime"] == datetime_map[eid]
+                if "created_datetime" in response.data:
+                    assert response.data["created_datetime"] == datetime_map[eid]
 
             response = self.client.patch(
                 f"/rest/{self.list_uri}/{project.pk}",
@@ -1347,7 +1348,8 @@ class AttributeTestMixin:
                     f"/rest/{self.detail_uri}/{version}/{eid}", format="json"
                 )
                 assert response.data["attributes"][attribute_name] == null_value
-                assert resposne.data["created_datetime"] == datetime_map[eid]
+                if "created_datetime" in response.data:
+                    assert response.data["created_datetime"] == datetime_map[eid]
 
     def test_bool_attr(self):
         test_vals = [random.random() > 0.5 for _ in range(len(self.entities))]
@@ -2595,7 +2597,7 @@ class LocalizationBoxTestCase(
     def setUp(self):
         super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
-        logging.disable(logging.CRITICAL)
+        # logging.disable(logging.CRITICAL)
         BurstableThrottle.apply_monkey_patching_for_test()
         self.user = create_test_user()
         self.user_two = create_test_user()

--- a/test/test_annotation.py
+++ b/test/test_annotation.py
@@ -64,6 +64,8 @@ def common_annotation(page, canvas, bias=0):
         page.mouse.move(x+50, y+50, steps=50)
         page.wait_for_timeout(1000)
         page.mouse.click(x+50, y+50)
+        selector = page.query_selector("entity-selector:visible")
+        selector.wait_for_selector(f'#current-index :text("{idx+1+bias}")')
         found = False
         for attempts in range(5):
             elemental_id_fields = page.query_selector_all("#metadata-elemental-id")

--- a/ui/src/js/annotation/entity-browser.js
+++ b/ui/src/js/annotation/entity-browser.js
@@ -255,7 +255,10 @@ export class EntityBrowser extends TatorElement {
       if (this._dataType.isLocalization) {
         groups[group].sort((item_a, item_b) => {
           if (item_a.frame === item_b.frame) {
-            return Date.parse(item_a.created_datetime) - Date.parse(item_b.created_datetime);
+            return (
+              Date.parse(item_a.created_datetime) -
+              Date.parse(item_b.created_datetime)
+            );
           }
           return item_a.frame - item_b.frame;
         });
@@ -268,14 +271,20 @@ export class EntityBrowser extends TatorElement {
             return 1;
           }
           if (item_a.segments[0][0] == item_b.segments[0][0]) {
-            return Date.parse(item_a.created_datetime) - Date.parse(item_b.created_datetime);
+            return (
+              Date.parse(item_a.created_datetime) -
+              Date.parse(item_b.created_datetime)
+            );
           }
           return item_a.segments[0][0] - item_b.segments[0][0];
         });
       } else {
         groups[group].sort((item_a, item_b) => {
           if (item_a.frame === item_b.frame) {
-            return Date.parse(item_a.created_datetime) - Date.parse(item_b.created_datetime);
+            return (
+              Date.parse(item_a.created_datetime) -
+              Date.parse(item_b.created_datetime)
+            );
           }
           return item_a.frame - item_b.frame;
         });

--- a/ui/src/js/annotation/entity-browser.js
+++ b/ui/src/js/annotation/entity-browser.js
@@ -255,7 +255,7 @@ export class EntityBrowser extends TatorElement {
       if (this._dataType.isLocalization) {
         groups[group].sort((item_a, item_b) => {
           if (item_a.frame === item_b.frame) {
-            return item_a.id - item_b.id;
+            return Date.parse(item_a.created_datetime) - Date.parse(item_b.created_datetime);
           }
           return item_a.frame - item_b.frame;
         });
@@ -268,14 +268,14 @@ export class EntityBrowser extends TatorElement {
             return 1;
           }
           if (item_a.segments[0][0] == item_b.segments[0][0]) {
-            return item_a.id - item_b.id;
+            return Date.parse(item_a.created_datetime) - Date.parse(item_b.created_datetime);
           }
           return item_a.segments[0][0] - item_b.segments[0][0];
         });
       } else {
         groups[group].sort((item_a, item_b) => {
           if (item_a.frame === item_b.frame) {
-            return item_a.id - item_b.id;
+            return Date.parse(item_a.created_datetime) - Date.parse(item_b.created_datetime);
           }
           return item_a.frame - item_b.frame;
         });

--- a/ui/src/js/components/entity-gallery-sort.js
+++ b/ui/src/js/components/entity-gallery-sort.js
@@ -110,7 +110,7 @@ export class EntityGallerySortSimple extends TatorElement {
     if (category == "Media") {
       this._options.value = "$name";
     } else {
-      this._options.value = "$id";
+      this._options.value = "$created_datetime";
     }
     this._initialized = true;
   }

--- a/ui/src/js/components/entity-panel/entity-panel-form.js
+++ b/ui/src/js/components/entity-panel/entity-panel-form.js
@@ -71,6 +71,11 @@ export class EntityGalleryPanelForm extends TatorElement {
     this._attributes.displayGoToTrack(false);
     this._attributes.displayGoToLocalization(false);
 
+    // Disable marks for media version of this panel
+    if ("media" in data) {
+      this._attributes.disableWidget("Mark");
+    }
+
     this._data = data;
 
     if (attributePanelData.attributes !== null) {


### PR DESCRIPTION
Removes "mark" attribute on Media rather than show undefined, unedited field
Switch default ordering to $created_datetime rather than $id
  - This maintains ordering effectively between 1.2 and 1.3 because nominally $id is incremental.
  - This maintains ordering on edits in 1.3 as created_datetime is now persistent across mark'd objects upon page revisit. 
  
  