### PR TITLE
1.2.10 hotfix

### DIFF
--- a/api/main/rest/_annotation_query.py
+++ b/api/main/rest/_annotation_query.py
@@ -8,6 +8,7 @@ import uuid
 from django.db.models import Subquery
 from django.db.models.functions import Coalesce
 from django.db.models import Q
+from django.db.models.expressions import F
 
 from ..models import Localization, LocalizationType, Media, MediaType, Section, State, StateType
 
@@ -235,6 +236,8 @@ def _get_annotation_psql_queryset(project, filter_ops, params, annotation_type):
     show_deleted = params.get("show_deleted")
     if not show_deleted:
         qs = qs.filter(variant_deleted=False)
+
+    qs = qs.filter(mark=F("latest_mark"))
 
     if params.get("float_array", None) == None:
         if params.get("sort_by", None):

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -2251,7 +2251,6 @@ class VideoTestCase(
         response = self.client.get(f"/rest/Medias/{self.project.pk}", format="json")
         assert response.data[0].get("incident", None) == None
 
-        print("About to create a bunch of boxes")
         # Make a whole bunch of boxes to make sure indices get utilized
         boxes = []
         foo_box = make_box_obj(
@@ -2269,7 +2268,35 @@ class VideoTestCase(
             },
         )
         boxes.append(foo_box)
+        foo_box = make_box_obj(
+            self.user,
+            box_type,
+            self.project,
+            self.entities[0],
+            0,
+            {
+                "String Test": "Foo",
+                "Enum Test": "enum_val1",
+                "Int Test": 1,
+                "Float Test": 1.0,
+                "Bool Test": True,
+            },
+        )
         boxes.append(foo_box)
+        foo_box = make_box_obj(
+            self.user,
+            box_type,
+            self.project,
+            self.entities[0],
+            0,
+            {
+                "String Test": "Foo",
+                "Enum Test": "enum_val1",
+                "Int Test": 1,
+                "Float Test": 1.0,
+                "Bool Test": True,
+            },
+        )
         boxes.append(foo_box)
 
         box = make_box_obj(
@@ -2343,6 +2370,9 @@ class VideoTestCase(
             ["Float Test", 1.0],
             ["Bool Test", True],
         ]
+        response = self.client.get(f"/rest/Localizations/{self.project.pk}", format=json)
+        self.assertEqual(len(response.data), len(boxes))
+
         for key, value in searches:
             response = self.client.get(
                 f"/rest/Localizations/{self.project.pk}?attribute={key}::{value}", format=json
@@ -2355,9 +2385,6 @@ class VideoTestCase(
                 f"/rest/Medias/{self.project.pk}?encoded_related_search={encoded_search.decode()}&sort_by=-$incident",
                 format="json",
             )
-            from pprint import pprint
-
-            pprint(response.data)
             first_hit = response.data[0]
             second_hit = response.data[1]
             self.assertEqual(first_hit.get("incident", None), 3)

--- a/ui/src/js/annotation/entity-browser.js
+++ b/ui/src/js/annotation/entity-browser.js
@@ -255,7 +255,10 @@ export class EntityBrowser extends TatorElement {
       if (this._dataType.isLocalization) {
         groups[group].sort((item_a, item_b) => {
           if (item_a.frame === item_b.frame) {
-            return Date.parse(item_a.created_datetime) - Date.parse(item_b.created_datetime);
+            return (
+              Date.parse(item_a.created_datetime) -
+              Date.parse(item_b.created_datetime)
+            );
           }
           return item_a.frame - item_b.frame;
         });
@@ -268,14 +271,20 @@ export class EntityBrowser extends TatorElement {
             return 1;
           }
           if (item_a.segments[0][0] == item_b.segments[0][0]) {
-            return Date.parse(item_a.created_datetime) - Date.parse(item_b.created_datetime);
+            return (
+              Date.parse(item_a.created_datetime) -
+              Date.parse(item_b.created_datetime)
+            );
           }
           return item_a.segments[0][0] - item_b.segments[0][0];
         });
       } else {
         groups[group].sort((item_a, item_b) => {
           if (item_a.frame === item_b.frame) {
-            return Date.parse(item_a.created_datetime) - Date.parse(item_b.created_datetime);
+            return (
+              Date.parse(item_a.created_datetime) -
+              Date.parse(item_b.created_datetime)
+            );
           }
           return item_a.frame - item_b.frame;
         });

--- a/ui/src/js/annotation/entity-browser.js
+++ b/ui/src/js/annotation/entity-browser.js
@@ -255,7 +255,7 @@ export class EntityBrowser extends TatorElement {
       if (this._dataType.isLocalization) {
         groups[group].sort((item_a, item_b) => {
           if (item_a.frame === item_b.frame) {
-            return item_a.id - item_b.id;
+            return Date.parse(item_a.created_datetime) - Date.parse(item_b.created_datetime);
           }
           return item_a.frame - item_b.frame;
         });
@@ -268,14 +268,14 @@ export class EntityBrowser extends TatorElement {
             return 1;
           }
           if (item_a.segments[0][0] == item_b.segments[0][0]) {
-            return item_a.id - item_b.id;
+            return Date.parse(item_a.created_datetime) - Date.parse(item_b.created_datetime);
           }
           return item_a.segments[0][0] - item_b.segments[0][0];
         });
       } else {
         groups[group].sort((item_a, item_b) => {
           if (item_a.frame === item_b.frame) {
-            return item_a.id - item_b.id;
+            return Date.parse(item_a.created_datetime) - Date.parse(item_b.created_datetime);
           }
           return item_a.frame - item_b.frame;
         });

--- a/ui/src/js/util/tator-data.js
+++ b/ui/src/js/util/tator-data.js
@@ -564,8 +564,7 @@ export class TatorData {
       url += "&presigned=28800";
     }
 
-    if (annotationType == "Localizations" || annotationType == "States")
-    {
+    if (annotationType == "Localizations" || annotationType == "States") {
       // For ordering to match if edits are done on 1.3.0+ we can sort by $created_datetime
       url += "&sort_by=$created_datetime";
     }

--- a/ui/src/js/util/tator-data.js
+++ b/ui/src/js/util/tator-data.js
@@ -564,6 +564,12 @@ export class TatorData {
       url += "&presigned=28800";
     }
 
+    if (annotationType == "Localizations" || annotationType == "States")
+    {
+      // For ordering to match if edits are done on 1.3.0+ we can sort by $created_datetime
+      url += "&sort_by=$created_datetime";
+    }
+
     console.log("Getting data with URL: " + url);
     var promises = [];
     promises.push(fetchCredentials(url, {}, true));


### PR DESCRIPTION
Now that 1.2.X has the models.py data, we can make REST accesses compatible with a database being worked with 1.3.X backend. 

This updates 1.2.X series to only return the latest mark of an object. It also updates the various views to maintain ordering of 1.2.X inferred by ID, but explicitly in created_datetime.