### PR TITLE
1.3.11 Hot fixes

### DIFF
--- a/api/main/rest/localization.py
+++ b/api/main/rest/localization.py
@@ -383,7 +383,7 @@ class LocalizationDetailBaseAPI(BaseDetailView):
             y = params.get("y", None)
             height = params.get("height", None)
             width = params.get("width", None)
-            thumbnail_image = params.get("thumbnail_image", None)
+
             if x is not None:
                 obj.x = x
             if y is not None:
@@ -397,13 +397,6 @@ class LocalizationDetailBaseAPI(BaseDetailView):
             if (x or y or height or width) and obj.thumbnail_image:
                 obj.thumbnail_image.delete()
 
-            if thumbnail_image:
-                try:
-                    thumbnail_obj = Media.objects.get(pk=thumbnail_image)
-                except Media.DoesNotExist:
-                    logger.error("Bad thumbnail reference given")
-                else:
-                    obj.thumbnail_image = thumbnail_obj
         elif obj.type.dtype == "line":
             x = params.get("x", None)
             y = params.get("y", None)

--- a/api/main/rest/media.py
+++ b/api/main/rest/media.py
@@ -802,11 +802,6 @@ class MediaDetailAPI(BaseDetailView):
                     )
 
         obj = Media.objects.get(pk=params["id"], deleted=False)
-        if "attributes" in params:
-            if obj.type.dtype == "image":
-                for localization in obj.localization_thumbnail_image.all():
-                    localization = patch_attributes(new_attrs, localization)
-                    localization.save()
 
         log_changes(obj, model_dict, obj.project, self.request.user)
         return {"message": f'Media {params["id"]} successfully updated!'}

--- a/api/main/schema/components/localization.py
+++ b/api/main/schema/components/localization.py
@@ -114,7 +114,7 @@ localization_get_properties = {
     },
     "thumbnail_image": {
         "type": "string",
-        "description": "URL of thumbnail corresponding to this localization.",
+        "description": "URL of thumbnail corresponding to this localization. (Deprecated)",
     },
     "version": {
         "type": "integer",


### PR DESCRIPTION
- Remove expensive `thumbnail_image` related query in Media PATCH calls