### PR TITLE
#1710 - Dynamic/more accurate frame entries when state creation modal is open

### DIFF
--- a/ui/src/js/annotation/annotation-page.js
+++ b/ui/src/js/annotation/annotation-page.js
@@ -1478,7 +1478,7 @@ export class AnnotationPage extends TatorPage {
               for (let [type, saveDialog] of Object.entries(this._saves)) {
                 if (type !== "modifyTrack") {
                   saveDialog.updateFrame(this._currentFrame);
-                } 
+                }
               }
             });
 

--- a/ui/src/js/annotation/annotation-page.js
+++ b/ui/src/js/annotation/annotation-page.js
@@ -1221,7 +1221,6 @@ export class AnnotationPage extends TatorPage {
               this._browser.frameChange(evt.detail.frame);
               this._settings.setAttribute("frame", evt.detail.frame);
               this._currentFrame = evt.detail.frame;
-
               // TODO: tempting to call '_updateURL' here but may be a performance bottleneck
             });
             canvas.addEventListener("select", (evt) => {
@@ -1472,6 +1471,16 @@ export class AnnotationPage extends TatorPage {
                 this._closeModal(save);
               });
             }
+
+            // Event listener to dynamically update save-dialog frame attribute
+            canvas.addEventListener("frameChange", (evt) => {
+              this._currentFrame = evt.detail.frame;
+              for (let [type, saveDialog] of Object.entries(this._saves)) {
+                if (type !== "modifyTrack") {
+                  saveDialog.updateFrame(this._currentFrame);
+                } 
+              }
+            });
 
             canvas.addEventListener("create", (evt) => {
               const metaMode = evt.detail.metaMode;

--- a/ui/src/js/annotation/save-dialog.js
+++ b/ui/src/js/annotation/save-dialog.js
@@ -97,7 +97,7 @@ export class SaveDialog extends TatorElement {
     this._attributes = document.createElement("attribute-panel");
     attrDiv.appendChild(this._attributes);
     this._attributes.disableWidget("ID");
-    this._attributes.disableWidget("Frame");
+    // this._attributes.disableWidget("Frame");
     this._attributes.disableWidget("Elemental ID");
     this._attributes.disableWidget("Mark");
 
@@ -175,6 +175,8 @@ export class SaveDialog extends TatorElement {
 
     // Used for continuous track append.
     this._trackId = null;
+
+    this._frame = 0;
   }
 
   init(projectId, mediaId, dataTypes, defaultType, undo, version, favorites) {
@@ -290,6 +292,18 @@ export class SaveDialog extends TatorElement {
   set version(val) {
     this._version = val;
     this._attributes._versionWidget.setValue(this._version.name);
+  }
+
+  // Used to dynamically update frame attribute
+  updateFrame(val) {
+    // Update the frame, set widget value
+    this._frame = val;
+    this._attributes._frameWidget.setValue(this._frame);
+
+    // Update _requestObj's frame (object used to save)
+    if (this._requestObj) {
+      this._requestObj.frame = this._frame;
+    }
   }
 
   set canvasPosition(val) {


### PR DESCRIPTION
Added method to dynamically update save dialog > attribute panel > Frame widget value. This enables users to save the current frame when the save dialog is open and the frame changes (video is still playing or video is paused and track slider adjusted). 

Previous behavior would save the frame at which users spawned the dialog. 