### PR TITLE
Fix localhost routing issues on docker compose setups

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -117,6 +117,8 @@ services:
     restart: always
     networks:
       - private
+    extra_hosts:
+      - ${USE_FAKE_LOCALHOST:+localhost:${LOCAL_IP}}
 
   ui:
     image: ${REGISTRY}/tator_ui:${GIT_VERSION}

--- a/compose.yaml
+++ b/compose.yaml
@@ -94,7 +94,7 @@ services:
       - ${DATA_DIR}/media:/media
       - ${DATA_DIR}/backup:/backup
     extra_hosts:
-      - ${USE_FAKE_LOCALHOST:+localhost:${LOCAL_IP}}
+      - localhost:${MASQUARADE_LOCALHOST_IP}
 
   transcode:
     image: ${REGISTRY}/tator_transcode:${GIT_VERSION}
@@ -120,7 +120,7 @@ services:
     networks:
       - private
     extra_hosts:
-      - ${USE_FAKE_LOCALHOST:+localhost:${LOCAL_IP}}
+      - localhost:${MASQUARADE_LOCALHOST_IP}
 
   ui:
     image: ${REGISTRY}/tator_ui:${GIT_VERSION}

--- a/compose.yaml
+++ b/compose.yaml
@@ -93,6 +93,8 @@ services:
       - ${DATA_DIR}/migrations:/tator_online/main/migrations
       - ${DATA_DIR}/media:/media
       - ${DATA_DIR}/backup:/backup
+    extra_hosts:
+      - ${USE_FAKE_LOCALHOST:+localhost:${LOCAL_IP}}
 
   transcode:
     image: ${REGISTRY}/tator_transcode:${GIT_VERSION}

--- a/example-env
+++ b/example-env
@@ -74,7 +74,7 @@ AUDIT_ENABLED=false
 # How long in seconds static files should be cached by browsers (set to 0 to disable caching, as in development)
 STATIC_MAX_AGE=2592000
 
-# If using localhost it is recommended to use the following settings (uncommented)
+# If using localhost it is recommended to use the following setting
 # This allows for docker containers to utilize localhost to mean the host machine
-#USE_FAKE_LOCALHOST=true
-#LOCAL_IP=<LAN_IP>
+#MASQUARADE_LOCALHOST_IP=<LAN_IP>
+MASQUARADE_LOCALHOST_IP=127.0.0.1

--- a/example-env
+++ b/example-env
@@ -73,3 +73,8 @@ AUDIT_ENABLED=false
 
 # How long in seconds static files should be cached by browsers (set to 0 to disable caching, as in development)
 STATIC_MAX_AGE=2592000
+
+# If using localhost it is recommended to use the following settings (uncommented)
+# This allows for docker containers to utilize localhost to mean the host machine
+#USE_FAKE_LOCALHOST=true
+#LOCAL_IP=<LAN_IP>


### PR DESCRIPTION
**Problem**: When using docker compose on some systems, host isolation of each container makes access another via localhost invalid. This happens due to the usage of presigned URLs in the transcode-worker container.

![image](https://github.com/user-attachments/assets/0be359e6-8aa1-4cd9-8af4-cabee2d2e791)

**Solution**: This adds an option to repoint `localhost` to the LAN_IP for affected containers (gunicorn and transcode-worker). This means generated presigned URLs will work as they get routed through nginx. 

