### PR TITLE
Utilize project-based lookup on individual element access

### DIFF
--- a/api/main/_permission_util.py
+++ b/api/main/_permission_util.py
@@ -509,8 +509,8 @@ def augment_permission(user, qs):
         # Calculate a dictionary for permissions by section and version in this set
         effected_media = qs.values("media_proj__pk")
         effected_sections = (
-            Section.objects.filter(project=project, media__in=effected_media)
-            .values("pk")
+            SectionMediaM2M.objects.filter(project=project, media__in=effected_media)
+            .values("section")
             .distinct()
         )
         effected_versions = qs.values("version__pk")

--- a/api/main/_permission_util.py
+++ b/api/main/_permission_util.py
@@ -499,7 +499,7 @@ def augment_permission(user, qs):
         #
 
         if model == Localization:
-            qs = qs.annotate(section=F("media__primary_section__pk"))
+            qs = qs.annotate(section=F("media_proj__primary_section__pk"))
         elif model == State:
             sb = Subquery(
                 Media.objects.filter(state__pk=OuterRef("pk")).values("primary_section__pk")[:1]
@@ -507,7 +507,7 @@ def augment_permission(user, qs):
             qs = qs.annotate(section=sb)
 
         # Calculate a dictionary for permissions by section and version in this set
-        effected_media = qs.values("media__pk")
+        effected_media = qs.values("media_proj__pk")
         effected_sections = (
             Section.objects.filter(project=project, media__in=effected_media)
             .values("pk")
@@ -538,7 +538,7 @@ def augment_permission(user, qs):
         }
 
         section_cases = [
-            When(media__primary_section=section, then=Value(perm))
+            When(media_proj__primary_section=section, then=Value(perm))
             for section, perm in section_perm_dict.items()
         ]
         version_cases = [

--- a/api/main/management/commands/backupresources.py
+++ b/api/main/management/commands/backupresources.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
     help = "Backs up any resource objects with `backed_up==False`."
 
     def handle(self, **options):
-        resource_qs = Resource.objects.filter(media__deleted=False, backed_up=False)
+        resource_qs = Resource.objects.filter(media_proj__deleted=False, backed_up=False)
 
         # Check for existence of default backup store
         default_backup_store = get_tator_store(backup=True)

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -127,7 +127,7 @@ RETURN NEW;
 @receiver(connection_created)
 def on_connection_created(sender, connection, **kwargs):
     http_method = get_http_method()
-    if http_method in ["PATCH", "POST"]:
+    if http_method in ["PATCH", "POST", "DELETE"]:
         logger.info(
             f"{http_method} detected, creating prepared statements."
         )  # useful for testing purposes

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -2551,3 +2551,12 @@ BUILT_IN_INDICES = {
         {"name": "$path", "dtype": "upper_string"},
     ],
 }
+
+if os.getenv("TATOR_EXT_MODELS", None):
+    import importlib
+    for module in os.getenv("TATOR_EXT_MODELS").split(","):
+        try:
+            importlib.import_module(module)
+        except Exception as e:
+            logger.error(f"Failed to import module {module}: {e}")
+            assert False

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -2463,6 +2463,22 @@ class RowProtection(Model):
         ]
 
 
+class ProjectLookup(Model):
+    """This Table defines an easy way to look up the project associated with a given object"""
+
+    media = ForeignKey(Media, on_delete=CASCADE, null=True, blank=True)
+    localization = ForeignKey(Localization, on_delete=CASCADE, null=True, blank=True)
+    state = ForeignKey(State, on_delete=CASCADE, null=True, blank=True)
+    project = ForeignKey(Project, on_delete=CASCADE, null=True, blank=True)
+    class Meta:
+        constraints = [
+            UniqueConstraint(
+                fields=["project", "media", "localization", "state"],
+                name="lookup_uniqueness_check",
+            )
+        ]
+
+
 # Structure to handle identifying columns with project-scoped indices
 # e.g. Not relaying solely on `db_index=True` in django.
 BUILT_IN_INDICES = {

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -9,6 +9,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.gis.db.models import Model
 from django.contrib.gis.db.models import ForeignKey
+from django.contrib.gis.db.models import ForeignObject
 from django.contrib.gis.db.models import ManyToManyField
 from django.contrib.gis.db.models import OneToOneField
 from django.contrib.gis.db.models import CharField

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -1547,7 +1547,7 @@ class Media(Model, ModelDiffMixin):
             media_qs = Media.objects.filter(pk__in=self.media_files["ids"])
             return all(media.is_backed_up() for media in media_qs.iterator())
 
-        resource_qs = Resource.objects.filter(media=self)
+        resource_qs = Resource.objects.filter(media_proj=self)
         return all(resource.backed_up for resource in resource_qs.iterator())
 
     def media_def_iterator(self, keys: List[str] = None) -> Generator[Tuple[str, dict], None, None]:

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -1682,9 +1682,10 @@ class File(Model, ModelDiffMixin):
 
 class Resource(Model):
     path = CharField(db_index=True, max_length=256)
-    media = ManyToManyField(
+    media = ManyToManyField(Media, related_name="resource_media")
+    media_proj = ManyToManyField(
         Media,
-        related_name="resource_media",
+        related_name="resource_media_proj",
         through="ResourceMedia",
         through_fields=("resource", "media_proj"),
     )

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -2248,7 +2248,7 @@ class Section(Model):
     attributes = JSONField(null=True, blank=True, default=dict)
 
     explicit_listing = BooleanField(default=False, null=True, blank=True)
-    # media = ManyToManyField(Media)
+    media = ManyToManyField(Media)
     media_proj = ManyToManyField(
         Media,
         related_name="section_media_proj",

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -1721,6 +1721,10 @@ class Resource(Model):
             if created:
                 obj.bucket = media.project.bucket
                 obj.save()
+            existing = ResourceMediaM2M.objects.filter(
+                resource=obj, media=media, project=media.project
+            )
+            if not existing:
                 ResourceMediaM2M.objects.create(resource=obj, media=media, project=media.project)
 
     @staticmethod

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -1687,7 +1687,7 @@ class Resource(Model):
     media_proj = ManyToManyField(
         Media,
         related_name="resource_media_proj",
-        through="ResourceMedia",
+        through="ResourceMediaM2M",
         through_fields=("resource", "media_proj"),
     )
     generic_files = ManyToManyField(File, related_name="resource_files")
@@ -1806,7 +1806,7 @@ class Resource(Model):
         return TatorBackupManager().finish_restore_resource(path, project, domain)
 
 
-class ResourceMedia(Model):
+class ResourceMediaM2M(Model):
     resource = ForeignKey(Resource, on_delete=CASCADE)
     media = ForeignKey(Media, on_delete=CASCADE)
     project = ForeignKey(Project, on_delete=CASCADE)
@@ -1817,6 +1817,10 @@ class ResourceMedia(Model):
         to_fields=("project", "id"),
         related_name="media_proj",
     )
+    class Meta:
+        constraints = [
+            UniqueConstraint(name="resourcem2m", fields=["resource", "project", "media"])
+        ]
 
 
 @receiver(post_save, sender=Media)

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -155,6 +155,18 @@ def create_prepared_statements(cursor):
         "PREPARE update_latest_mark_state(UUID, INT) AS UPDATE main_state SET latest_mark=(SELECT COALESCE(MAX(mark),0) FROM main_state WHERE elemental_id=$1 AND version=$2 AND deleted=FALSE) WHERE elemental_id=$1 AND version=$2;"
     )
 
+    cursor.execute(
+        "PREPARE update_lookup_media(INT, INT) AS INSERT INTO main_projectlookup (project_id, media_id) VALUES ($1, $2) ON CONFLICT DO NOTHING;"
+    )
+
+    cursor.execute(
+        "PREPARE update_lookup_localization(INT, INT) AS INSERT INTO main_projectlookup (project_id, localization_id) VALUES ($1, $2) ON CONFLICT DO NOTHING;"
+    )
+
+    cursor.execute(
+        "PREPARE update_lookup_state(INT, INT) AS INSERT INTO main_projectlookup (project_id, state_id) VALUES ($1, $2) ON CONFLICT DO NOTHING;"
+    )
+
 
 class ModelDiffMixin(object):
     """

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -115,6 +115,12 @@ END  IF;
 RETURN NEW;
 """
 
+UPDATE_LOOKUP_TRIGGER_FUNC = """
+SET plan_cache_mode=force_generic_plan;
+EXECUTE format('EXECUTE update_lookup_{0}(%s,%s)', NEW.project::integer, NEW.id::integer);
+SET plan_cache_mode=auto;
+RETURN NEW;
+"""
 
 # Register prepared statements for the triggers to optimize performance on creation of a database  connection
 @receiver(connection_created)
@@ -1401,6 +1407,15 @@ class Media(Model, ModelDiffMixin):
 
 
     """
+    class Meta:
+        triggers = [
+            pgtrigger.Trigger(
+                name="post_media_update_lookup",
+                operation=pgtrigger.Insert,
+                when=pgtrigger.After,
+                func=UPDATE_LOOKUP_TRIGGER_FUNC.format("media"),
+            ),
+        ]
 
     project = ForeignKey(
         Project,
@@ -1873,6 +1888,12 @@ class Localization(Model, ModelDiffMixin):
                 declare=[("_var", "integer")],
                 func=AFTER_MARK_TRIGGER_FUNC.format("localization"),
             ),
+            pgtrigger.Trigger(
+                name="post_localization_update_lookup",
+                operation=pgtrigger.Insert,
+                when=pgtrigger.After,
+                func=UPDATE_LOOKUP_TRIGGER_FUNC.format("localization"),
+            ),
         ]
 
     project = ForeignKey(Project, on_delete=SET_NULL, null=True, blank=True, db_column="project")
@@ -1977,6 +1998,12 @@ class State(Model, ModelDiffMixin):
                 condition=pgtrigger.Q(old__deleted=False, new__deleted=True),
                 declare=[("_var", "integer")],
                 func=AFTER_MARK_TRIGGER_FUNC.format("state"),
+            ),
+            pgtrigger.Trigger(
+                name="post_state_update_lookup",
+                operation=pgtrigger.Insert,
+                when=pgtrigger.After,
+                func=UPDATE_LOOKUP_TRIGGER_FUNC.format("state"),
             ),
         ]
 

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -1924,13 +1924,14 @@ class Localization(Model, ModelDiffMixin):
         db_column="modified_by",
     )
     user = ForeignKey(User, on_delete=PROTECT, db_column="user")
-    media_id = IntegerField(null=True, blank=True, db_column="media")
-    media = ForeignObject(
-        Media,
+    media = IntegerField(null=True, blank=True, db_column="media")
+    media_proj = ForeignObject(
+        to=Media,
         on_delete=CASCADE,
         to_fields=["project", "id"],
         from_fields=["project", "media"],
         null=True,
+        name="media_proj",
     )
     frame = PositiveIntegerField(null=True, blank=True)
     thumbnail_image = ForeignKey(

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -2243,7 +2243,29 @@ class Section(Model):
     attributes = JSONField(null=True, blank=True, default=dict)
 
     explicit_listing = BooleanField(default=False, null=True, blank=True)
-    media = ManyToManyField(Media)
+    # media = ManyToManyField(Media)
+    media_proj = ManyToManyField(
+        Media,
+        related_name="section_media_proj",
+        through="SectionMediaM2M",
+        through_fields=("section", "media_proj"),
+    )
+
+
+class SectionMediaM2M(Model):
+    section = ForeignKey(Section, on_delete=CASCADE)
+    media = ForeignKey(Media, on_delete=CASCADE)
+    project = ForeignKey(Project, on_delete=CASCADE)
+    media_proj = ForeignObject(
+        to=Media,
+        on_delete=CASCADE,
+        from_fields=("project", "media"),
+        to_fields=("project", "id"),
+        related_name="media_proj",
+    )
+
+    class Meta:
+        constraints = [UniqueConstraint(name="sectionm2m", fields=["section", "project", "media"])]
 
 
 class Favorite(Model):

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -1721,7 +1721,7 @@ class Resource(Model):
             if created:
                 obj.bucket = media.project.bucket
                 obj.save()
-            ResourceMedia.objects.create(resource=obj, media=media, project=media.project)
+                ResourceMediaM2M.objects.create(resource=obj, media=media, project=media.project)
 
     @staticmethod
     @transaction.atomic
@@ -1816,6 +1816,7 @@ class ResourceMediaM2M(Model):
         from_fields=("project", "media"),
         to_fields=("project", "id"),
         related_name="media_proj",
+        null=True,
     )
     class Meta:
         constraints = [
@@ -1861,7 +1862,7 @@ def drop_media_from_resource(path, media):
     try:
         logger.info(f"Dropping media {media} from resource {path}")
         obj = Resource.objects.get(path=path)
-        matches = ResourceMedia.objects.filter(resource=obj, media=media)
+        matches = ResourceMediaM2M.objects.filter(resource=obj, media=media)
         matches.delete()
     except:
         logger.warning(f"Could not remove {media} from {path}", exc_info=True)
@@ -2261,7 +2262,8 @@ class SectionMediaM2M(Model):
         on_delete=CASCADE,
         from_fields=("project", "media"),
         to_fields=("project", "id"),
-        related_name="media_proj",
+        related_name="sm_media_proj",
+        null=True,
     )
 
     class Meta:

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -1928,8 +1928,8 @@ class Localization(Model, ModelDiffMixin):
     media_proj = ForeignObject(
         to=Media,
         on_delete=CASCADE,
-        to_fields=["project", "id"],
-        from_fields=["project", "media"],
+        to_fields=("project", "id"),
+        from_fields=("project", "media"),
         null=True,
         name="media_proj",
     )

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -1924,7 +1924,14 @@ class Localization(Model, ModelDiffMixin):
         db_column="modified_by",
     )
     user = ForeignKey(User, on_delete=PROTECT, db_column="user")
-    media = ForeignKey(Media, on_delete=SET_NULL, null=True, blank=True, db_column="media")
+    media_id = IntegerField(null=True, blank=True, db_column="media")
+    media = ForeignObject(
+        Media,
+        on_delete=CASCADE,
+        to_fields=["project", "id"],
+        from_fields=["project", "media"],
+        null=True,
+    )
     frame = PositiveIntegerField(null=True, blank=True)
     thumbnail_image = ForeignKey(
         Media,

--- a/api/main/models.py
+++ b/api/main/models.py
@@ -1683,7 +1683,7 @@ class File(Model, ModelDiffMixin):
 class Resource(Model):
     path = CharField(db_index=True, max_length=256)
     # Comment this out to find all usages
-    # media = ManyToManyField(Media, related_name="resource_media")
+    media = ManyToManyField(Media, related_name="resource_media")
     media_proj = ManyToManyField(
         Media,
         related_name="resource_media_proj",

--- a/api/main/rest/_annotation_query.py
+++ b/api/main/rest/_annotation_query.py
@@ -179,7 +179,7 @@ def _get_annotation_psql_queryset(project, filter_ops, params, annotation_type):
             related_object_search = section.related_object_search
             media_qs = Media.objects.filter(project=project, type=media_type_id)
             if section.explicit_listing:
-                media_qs = Media.objects.filter(pk__in=section.media.values("id"))
+                media_qs = Media.objects.filter(pk__in=section.media_proj.values("id"))
                 logger.info(f"Explicit listing: {media_ids}")
             elif section_uuid:
                 media_qs = _look_for_section_uuid(media_qs, section_uuid)

--- a/api/main/rest/_media_query.py
+++ b/api/main/rest/_media_query.py
@@ -212,7 +212,7 @@ def _get_media_psql_queryset(project, filter_ops, params):
             section_uuid = section.tator_user_sections
 
             if section.explicit_listing:
-                match_qs = qs.filter(pk__in=section.media.all())
+                match_qs = qs.filter(pk__in=section.media_proj.all())
             elif section_uuid:
                 match_qs = _look_for_section_uuid(qs, section_uuid)
 

--- a/api/main/rest/_media_util.py
+++ b/api/main/rest/_media_util.py
@@ -26,7 +26,7 @@ class MediaUtil:
         # If available we only attempt to fetch
         # the part of the file we need to
         self._segment_info = None
-        resources = Resource.objects.filter(media__in=[video])
+        resources = Resource.objects.filter(media_proj__in=[video])
         store_lookup = get_storage_lookup(resources)
 
         if "streaming" in video.media_files:

--- a/api/main/rest/localization.py
+++ b/api/main/rest/localization.py
@@ -212,7 +212,7 @@ class LocalizationListAPI(BaseListView):
             Localization(
                 project=project,
                 type=metas[loc_spec["type"]],
-                media=medias[loc_spec["media_id"]],
+                media=medias[loc_spec["media_id"]].pk,
                 user=compute_user(
                     project, self.request.user, loc_spec.get("user_elemental_id", None)
                 ),

--- a/api/main/rest/localization_graphic.py
+++ b/api/main/rest/localization_graphic.py
@@ -256,7 +256,7 @@ class LocalizationGraphicAPI(BaseDetailView):
         # By reaching here, it's expected that the graphics mode is to create a new
         # thumbnail using the provided parameters. That new thumbnail is returned
         with tempfile.TemporaryDirectory() as temp_dir:
-            media_util = MediaUtil(video=obj.media, temp_dir=temp_dir)
+            media_util = MediaUtil(video=obj.media_proj, temp_dir=temp_dir)
 
             roi = self._getRoi(
                 obj=obj,

--- a/api/main/rest/media.py
+++ b/api/main/rest/media.py
@@ -107,7 +107,8 @@ def _presign(user_id, expiration, medias, fields=None, no_cache=False):
         "attachment",
     ]
     media_ids = set([media["id"] for media in medias])
-    resources = Resource.objects.filter(media__in=media_ids)
+    media_objs = Media.objects.filter(pk__in=media_ids)
+    resources = Resource.objects.filter(media_proj__in=media_objs)
     store_lookup = get_storage_lookup(resources)
     cache = TatorCache()
     ttl = expiration - 3600

--- a/api/main/rest/media.py
+++ b/api/main/rest/media.py
@@ -28,6 +28,7 @@ from ..models import (
     database_qs,
     database_query_ids,
     Version,
+    ProjectLookup,
 )
 from .._permission_util import PermissionMask
 
@@ -919,4 +920,8 @@ class MediaDetailAPI(BaseDetailView):
         return {"message": f'Media {params["id"]} successfully deleted!'}
 
     def get_queryset(self, **kwargs):
-        return Media.objects.filter(pk=self.params["id"], deleted=False)
+        return Media.objects.filter(
+            project=ProjectLookup.objects.get(media=self.params["id"]).project,
+            pk=self.params["id"],
+            deleted=False,
+        )

--- a/api/main/rest/permalink.py
+++ b/api/main/rest/permalink.py
@@ -46,8 +46,9 @@ def _presign(expiration, medias, fields=None):
         "thumbnail_gif",
         "attachment",
     ]
-    media_ids = [media["id"] for media in medias]
-    resources = Resource.objects.filter(media__in=media_ids)
+    media_objs = Media.objects.filter(pk__in=[media["id"] for media in medias])
+    resources = Resource.objects.filter(media_proj__in=media_objs)
+    logger.info(f"resources = {resources}")
     storage_lookup = get_storage_lookup(resources)
 
     # Get replace all keys with presigned urls.

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -44,8 +44,9 @@ TEST_IMAGE = (
 class TatorTransactionTest(APITransactionTestCase):
     """Handle cases when test runner flushes DB and indices are still being made."""
 
-    def setUp(self):
-        # Need to do this for first test in a test db instance
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         with connection.cursor() as cursor:
             create_prepared_statements(cursor)
 

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -2429,10 +2429,10 @@ class AnonymousAccessTestCase(TatorTransactionTest):
         self.test_bucket = create_test_bucket(None)
         resource = Resource(path="fake_key.txt", bucket=self.test_bucket)
         resource.save()
-        ResourceMedia.objects.create(
+        ResourceMediaM2M.objects.create(
             resource=resource, media=self.public_video, project=self.public_video.project
         )
-        ResourceMedia.objects.create(
+        ResourceMediaM2M.objects.create(
             resource=resource, media=self.private_video, project=self.private_video.project
         )
         resource.save()
@@ -6806,7 +6806,7 @@ class SectionTestCase(TatorTransactionTest):
 class AdvancedPermissionTestCase(TatorTransactionTest):
     def setUp(self):
         super().setUp()
-        logging.disable(logging.CRITICAL)
+        # logging.disable(logging.CRITICAL)
         # Add 9 users
         names = ["Alice", "Bob", "Charlie", "David", "Eve", "Frank", "Grace", "Hank", "Ivy"]
         self.users = [create_test_user(is_staff=False, username=name) for name in names]
@@ -6895,13 +6895,17 @@ class AdvancedPermissionTestCase(TatorTransactionTest):
         self.private_media = [v.pk for v in self.videos[3:6]]
 
         for media in self.videos[:3]:
-            self.public_section.media.add(media)
+            SectionMediaM2M.objects.create(
+                section=self.public_section, media=media, project=media.project
+            )
             self.public_section.save()
             media.primary_section = self.public_section
             media.save()
 
         for media in self.videos[3:6]:
-            self.private_section.media.add(media)
+            SectionMediaM2M.objects.create(
+                section=self.private_section, media=media, project=media.project
+            )
             self.private_section.save()
             media.primary_section = self.private_section
             media.save()
@@ -7116,6 +7120,7 @@ class AdvancedPermissionTestCase(TatorTransactionTest):
                 localization_qs = Localization.objects.filter(
                     project=self.project, media_proj=media
                 )
+                logger.info(f"Checking localizations for {media.pk}")
                 localization_qs = augment_permission(user, localization_qs)
                 if media.primary_section:
                     media_primary_section_pk = media.primary_section.pk

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -7109,7 +7109,9 @@ class AdvancedPermissionTestCase(TatorTransactionTest):
 
             # Test effective permission for boxes in media match expected result
             for media in media_qs:
-                localization_qs = Localization.objects.filter(project=self.project, media=media)
+                localization_qs = Localization.objects.filter(
+                    project=self.project, media_proj=media
+                )
                 localization_qs = augment_permission(user, localization_qs)
                 if media.primary_section:
                     media_primary_section_pk = media.primary_section.pk

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -3068,6 +3068,10 @@ class LocalizationBoxTestCase(
             )
             for idx in range(random.randint(6, 10))
         ]
+        for e in self.entities:
+            lookup = ProjectLookup.objects.get(project=e.project, localization=e.pk)
+            assert lookup.project.pk == e.project.pk
+            assert lookup.localization.pk == e.pk
         self.list_uri = "Localizations"
         self.detail_uri = "Localization"
         self.create_entity = functools.partial(
@@ -3153,6 +3157,10 @@ class LocalizationLineTestCase(
             )
             for idx in range(random.randint(6, 10))
         ]
+        for e in self.entities:
+            lookup = ProjectLookup.objects.get(project=e.project, localization=e.pk)
+            assert lookup.project.pk == e.project.pk
+            assert lookup.localization.pk == e.pk
         self.list_uri = "Localizations"
         self.detail_uri = "Localization"
         self.create_entity = functools.partial(
@@ -3238,6 +3246,10 @@ class LocalizationDotTestCase(
             )
             for idx in range(random.randint(6, 10))
         ]
+        for e in self.entities:
+            lookup = ProjectLookup.objects.get(project=e.project, localization=e.pk)
+            assert lookup.project.pk == e.project.pk
+            assert lookup.localization.pk == e.pk
         self.list_uri = "Localizations"
         self.detail_uri = "Localization"
         self.create_entity = functools.partial(
@@ -3321,6 +3333,10 @@ class LocalizationPolyTestCase(
             )
             for idx in range(random.randint(6, 10))
         ]
+        for e in self.entities:
+            lookup = ProjectLookup.objects.get(project=e.project, localization=e.pk)
+            assert lookup.project.pk == e.project.pk
+            assert lookup.localization.pk == e.pk
         self.list_uri = "Localizations"
         self.detail_uri = "Localization"
         self.create_entity = functools.partial(
@@ -3406,6 +3422,10 @@ class StateTestCase(
             for media in random.choices(self.media_entities):
                 state.media.add(media)
             self.entities.append(state)
+        for e in self.entities:
+            lookup = ProjectLookup.objects.get(project=e.project, state=e.pk)
+            assert lookup.project.pk == e.project.pk
+            assert lookup.state.pk == e.pk
         self.list_uri = "States"
         self.detail_uri = "State"
         self.create_entity = functools.partial(

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -2429,8 +2429,12 @@ class AnonymousAccessTestCase(TatorTransactionTest):
         self.test_bucket = create_test_bucket(None)
         resource = Resource(path="fake_key.txt", bucket=self.test_bucket)
         resource.save()
-        resource.media.add(self.public_video)
-        resource.media.add(self.private_video)
+        ResourceMedia.objects.create(
+            resource=resource, media=self.public_video, project=self.public_video.project
+        )
+        ResourceMedia.objects.create(
+            resource=resource, media=self.private_video, project=self.private_video.project
+        )
         resource.save()
 
     def test_random_user(self):

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -2177,6 +2177,7 @@ class FileMixin:
 
 class CurrentUserTestCase(TatorTransactionTest):
     def setUp(self):
+        super().setUp()
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
         self.client.force_authenticate(self.user)
@@ -2301,6 +2302,7 @@ class CurrentUserTestCase(TatorTransactionTest):
 
 class ProjectDeleteTestCase(TatorTransactionTest):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -2368,6 +2370,7 @@ class AlgorithmLaunchTestCase(
 
 class AlgorithmTestCase(TatorTransactionTest, PermissionListMembershipTestMixin):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -2385,6 +2388,7 @@ class AlgorithmTestCase(TatorTransactionTest, PermissionListMembershipTestMixin)
 
 class AnonymousAccessTestCase(TatorTransactionTest):
     def setUp(self):
+        super().setUp()
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
         self.random_user = create_test_user()
@@ -2471,6 +2475,7 @@ class VideoTestCase(
     PermissionDetailTestMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -2969,6 +2974,7 @@ class ImageTestCase(
     PermissionDetailTestMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -3109,6 +3115,7 @@ class LocalizationLineTestCase(
     AttributeRenameMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         BurstableThrottle.apply_monkey_patching_for_test()
@@ -3193,6 +3200,7 @@ class LocalizationDotTestCase(
     AttributeRenameMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         BurstableThrottle.apply_monkey_patching_for_test()
@@ -3275,6 +3283,7 @@ class LocalizationPolyTestCase(
     AttributeRenameMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         BurstableThrottle.apply_monkey_patching_for_test()
@@ -3356,6 +3365,7 @@ class StateTestCase(
     AttributeRenameMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         # logging.disable(logging.CRITICAL)
         BurstableThrottle.apply_monkey_patching_for_test()
@@ -3469,6 +3479,7 @@ class StateTestCase(
 
 class LocalizationMediaDeleteCase(TatorTransactionTest):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -3749,6 +3760,7 @@ class LocalizationMediaDeleteCase(TatorTransactionTest):
 
 class StateMediaDeleteCase(TatorTransactionTest):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -3965,6 +3977,7 @@ class LeafTestCase(
     PermissionDetailTestMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -4088,6 +4101,7 @@ class LeafTypeTestCase(
     PermissionDetailTestMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -4115,6 +4129,7 @@ class StateTypeTestCase(
     PermissionDetailTestMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -4162,6 +4177,7 @@ class MediaTypeTestCase(
     PermissionDetailTestMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -4205,6 +4221,7 @@ class LocalizationTypeTestCase(
     PermissionDetailTestMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -4277,6 +4294,7 @@ if os.getenv("TATOR_FINE_GRAIN_PERMISSION") != "true":
         TatorTransactionTest, PermissionListMembershipTestMixin, PermissionDetailTestMixin
     ):
         def setUp(self):
+            super().setUp()
             print(f"\n{self.__class__.__name__}=", end="", flush=True)
             logging.disable(logging.CRITICAL)
             self.user = create_test_user()
@@ -4300,6 +4318,7 @@ if os.getenv("TATOR_FINE_GRAIN_PERMISSION") != "true":
 
 class ProjectTestCase(TatorTransactionTest):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -4464,6 +4483,7 @@ class ProjectTestCase(TatorTransactionTest):
 
 class TranscodeTestCase(TatorTransactionTest, PermissionCreateTestMixin):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -4499,6 +4519,7 @@ class VersionTestCase(
     PermissionDetailTestMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -4595,6 +4616,7 @@ class FavoriteStateTestCase(
     PermissionDetailTestMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         self.user = create_test_user()
         self.client.force_authenticate(self.user)
@@ -4644,6 +4666,7 @@ class FavoriteLocalizationTestCase(
     PermissionDetailTestMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -4691,6 +4714,7 @@ class BookmarkTestCase(
     PermissionDetailTestMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -4725,6 +4749,7 @@ class AffiliationTestCase(
     PermissionDetailAffiliationTestMixin,
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -4758,6 +4783,7 @@ class AffiliationTestCase(
 
 class OrganizationTestCase(TatorTransactionTest, PermissionDetailAffiliationTestMixin):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user(is_staff=True)
@@ -4855,6 +4881,7 @@ class BucketTestCase(
     TatorTransactionTest, PermissionListAffiliationTestMixin, PermissionDetailAffiliationTestMixin
 ):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -4903,6 +4930,7 @@ class BucketTestCase(
 
 class ImageFileTestCase(TatorTransactionTest, FileMixin):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -4937,6 +4965,7 @@ class ImageFileTestCase(TatorTransactionTest, FileMixin):
 
 class VideoFileTestCase(TatorTransactionTest, FileMixin):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -4978,6 +5007,7 @@ class VideoFileTestCase(TatorTransactionTest, FileMixin):
 
 class AudioFileTestCase(TatorTransactionTest, FileMixin):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -5006,6 +5036,7 @@ class AudioFileTestCase(TatorTransactionTest, FileMixin):
 
 class AuxiliaryFileTestCase(TatorTransactionTest, FileMixin):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -5044,6 +5075,7 @@ class ResourceTestCase(TatorTransactionTest):
     }
 
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -5611,6 +5643,7 @@ class ResourceWithBackupTestCase(ResourceTestCase):
     """This runs the same tests as `ResourceTestCase` but adds project-specific buckets"""
 
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -5643,6 +5676,7 @@ class ResourceWithBackupTestCase(ResourceTestCase):
 
 class AttributeTestCase(TatorTransactionTest):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -5858,6 +5892,7 @@ class MutateAliasTestCase(TatorTransactionTest):
     """Tests alias mutation."""
 
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -6038,6 +6073,7 @@ class JobClusterTestCase(TatorTransactionTest):
         return Affiliation.objects.filter(organization=organization, user=user)[0]
 
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -6115,6 +6151,7 @@ class HostedTemplateTestCase(TatorTransactionTest):
         return Affiliation.objects.filter(organization=organization, user=user)[0]
 
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()
@@ -6179,6 +6216,7 @@ class HostedTemplateTestCase(TatorTransactionTest):
 
 class UsernameTestCase(TatorTransactionTest):
     def setUp(self):
+        super().setUp()
         self.list_uri = "Users"
         self.detail_uri = "User"
 
@@ -6221,6 +6259,7 @@ class UsernameTestCase(TatorTransactionTest):
 
 class SectionTestCase(TatorTransactionTest):
     def setUp(self):
+        super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
         logging.disable(logging.CRITICAL)
         self.user = create_test_user()

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -44,9 +44,8 @@ TEST_IMAGE = (
 class TatorTransactionTest(APITransactionTestCase):
     """Handle cases when test runner flushes DB and indices are still being made."""
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUp(self):
+        # Need to do this for first test in a test db instance
         with connection.cursor() as cursor:
             create_prepared_statements(cursor)
 

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -1382,7 +1382,6 @@ class PermissionDetailAffiliationTestMixin:
                 if expected_status == status.HTTP_200_OK:
                     del self.entities[0]
 
-
 class AttributeMediaTestMixin:
     def test_media_with_attr(self):
         response = self.client.get(
@@ -2498,6 +2497,12 @@ class VideoTestCase(
             )
             for idx in range(random.randint(6, 10))
         ]
+
+        for e in self.entities:
+            lookup = ProjectLookup.objects.get(project=e.project, media=e.pk)
+            assert lookup.project.pk == e.project.pk
+            assert lookup.media.pk == e.pk
+
         self.media_entities = self.entities
         self.list_uri = "Medias"
         self.detail_uri = "Media"
@@ -2988,6 +2993,12 @@ class ImageTestCase(
             )
             for idx in range(random.randint(6, 10))
         ]
+
+        for e in self.entities:
+            lookup = ProjectLookup.objects.get(project=e.project, media=e.pk)
+            assert lookup.project.pk == e.project.pk
+            assert lookup.media.pk == e.pk
+
         self.media_entities = self.entities
         self.list_uri = "Medias"
         self.detail_uri = "Media"

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -5436,8 +5436,8 @@ class ResourceTestCase(TatorTransactionTest):
 
         self.assertTrue(self._store_obj_exists(image_key))
         self.assertTrue(self._store_obj_exists(thumb_key))
-        self.assertEqual(Resource.objects.get(path=image_key).media.all()[0].pk, image_id)
-        self.assertEqual(Resource.objects.get(path=thumb_key).media.all()[0].pk, image_id)
+        self.assertEqual(Resource.objects.get(path=image_key).media_proj.all()[0].pk, image_id)
+        self.assertEqual(Resource.objects.get(path=thumb_key).media_proj.all()[0].pk, image_id)
 
         # Delete the media and verify the files are gone.
         response = self.client.delete(f"/rest/Media/{image_id}", format="json")
@@ -5468,8 +5468,8 @@ class ResourceTestCase(TatorTransactionTest):
 
         self.assertTrue(self._store_obj_exists(image_key))
         self.assertTrue(self._store_obj_exists(thumb_key))
-        self.assertEqual(Resource.objects.get(path=image_key).media.all()[0].pk, image_id)
-        self.assertEqual(Resource.objects.get(path=thumb_key).media.all()[0].pk, image_id)
+        self.assertEqual(Resource.objects.get(path=image_key).media_proj.all()[0].pk, image_id)
+        self.assertEqual(Resource.objects.get(path=thumb_key).media_proj.all()[0].pk, image_id)
 
         # Delete the media and verify the files are gone.
         response = self.client.delete(f"/rest/Media/{image_id}", format="json")
@@ -5499,8 +5499,8 @@ class ResourceTestCase(TatorTransactionTest):
         gif_key = video.media_files["thumbnail_gif"][0]["path"]
         self.assertTrue(self._store_obj_exists(thumb_key))
         self.assertTrue(self._store_obj_exists(gif_key))
-        self.assertEqual(Resource.objects.get(path=thumb_key).media.all()[0].pk, video_id)
-        self.assertEqual(Resource.objects.get(path=gif_key).media.all()[0].pk, video_id)
+        self.assertEqual(Resource.objects.get(path=thumb_key).media_proj.all()[0].pk, video_id)
+        self.assertEqual(Resource.objects.get(path=gif_key).media_proj.all()[0].pk, video_id)
 
         # Delete the media and verify the files are gone.
         response = self.client.delete(f"/rest/Media/{video_id}", format="json")

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -6801,6 +6801,7 @@ class SectionTestCase(TatorTransactionTest):
 
 class AdvancedPermissionTestCase(TatorTransactionTest):
     def setUp(self):
+        super().setUp()
         logging.disable(logging.CRITICAL)
         # Add 9 users
         names = ["Alice", "Bob", "Charlie", "David", "Eve", "Frank", "Grace", "Hank", "Ivy"]

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -294,7 +294,7 @@ def create_test_box(user, entity_type, project, media, frame, attributes={}, ver
         type=entity_type,
         project=project,
         version=version,
-        media=media,
+        media=media.pk,
         frame=frame,
         x=x,
         y=y,
@@ -316,7 +316,7 @@ def make_box_obj(user, entity_type, project, media, frame, attributes={}):
         type=entity_type,
         project=project,
         version=project.version_set.all()[0],
-        media=media,
+        media=media.pk,
         frame=frame,
         x=x,
         y=y,
@@ -345,7 +345,7 @@ def create_test_line(user, entity_type, project, media, frame, attributes={}):
         type=entity_type,
         project=project,
         version=project.version_set.all()[0],
-        media=media,
+        media=media.pk,
         frame=frame,
         x=x0,
         y=y0,
@@ -365,7 +365,7 @@ def create_test_dot(user, entity_type, project, media, frame, attributes={}):
         type=entity_type,
         project=project,
         version=project.version_set.all()[0],
-        media=media,
+        media=media.pk,
         frame=frame,
         x=x,
         y=y,
@@ -3032,7 +3032,7 @@ class LocalizationBoxTestCase(
     def setUp(self):
         super().setUp()
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
-        # logging.disable(logging.CRITICAL)
+        logging.disable(logging.CRITICAL)
         BurstableThrottle.apply_monkey_patching_for_test()
         self.user = create_test_user()
         self.user_two = create_test_user()

--- a/api/main/util.py
+++ b/api/main/util.py
@@ -1414,9 +1414,8 @@ def migrate_old_many_to_many():
     from django.db import connection
 
     with connection.cursor() as cursor:
-
         # Handle resource many to many first
-        cursor.execute("DELETE * FROM main_resourcemedia")
+        cursor.execute("DELETE FROM main_resourcemedia")
         cursor.execute(
             'INSERT INTO main_resourcemedia (resource_id, media_id, project_id) SELECT "main_resource".id, "main_media".id, "main_media".project FROM main_resource_media LEFT OUTER JOIN "main_media" ON ("main_resource_media"."media_id" = "main_media"."id") LEFT OUTER JOIN "main_resource" ON ("main_resource_media"."resource_id" = "main_resource"."id")'
         )

--- a/api/main/util.py
+++ b/api/main/util.py
@@ -1408,3 +1408,15 @@ def fill_lookup_table(project_id, dry_run=False):
         ProjectLookup.objects.bulk_create(data)
     print(f"Completed states for {project_id}")
     data = []
+
+
+def migrate_old_many_to_many():
+    from django.db import connection
+
+    with connection.cursor() as cursor:
+
+        # Handle resource many to many first
+        cursor.execute("DELETE * FROM main_resourcemedia")
+        cursor.execute(
+            'INSERT INTO main_resourcemedia (resource_id, media_id, project_id) SELECT "main_resource".id, "main_media".id, "main_media".project FROM main_resource_media LEFT OUTER JOIN "main_media" ON ("main_resource_media"."media_id" = "main_media"."id") LEFT OUTER JOIN "main_resource" ON ("main_resource_media"."resource_id" = "main_resource"."id")'
+        )

--- a/api/main/util.py
+++ b/api/main/util.py
@@ -1390,7 +1390,7 @@ def fill_lookup_table(project_id, dry_run=False):
 
     print(f"Completed media for {project_id}")
     for l in unhandled_localizations.iterator(chunk_size=500):
-        data.append(ProjectLookup(project_id=project_id, media_id=l.id))
+        data.append(ProjectLookup(project_id=project_id, localization_id=l.id))
         if len(data) == 500:
             ProjectLookup.objects.bulk_create(data)
             data = []

--- a/api/main/util.py
+++ b/api/main/util.py
@@ -853,7 +853,7 @@ def get_clone_info(media: Media) -> dict:
         media_dict["original"]["media"] = Media.objects.get(pk=media_id)
 
         # Shared base queryset
-        media_qs = Media.objects.filter(resource_media__path__in=paths)
+        media_qs = Media.objects.filter(resource_media_proj__path__in=paths)
         media_dict["clones"].update(ele for ele in media_qs.values_list("id", flat=True))
         media_dict["clones"].remove(media_dict["original"]["media"].id)
     else:

--- a/api/main/util.py
+++ b/api/main/util.py
@@ -1417,5 +1417,5 @@ def migrate_old_many_to_many():
         # Handle resource many to many first
         cursor.execute("DELETE FROM main_resourcemedia")
         cursor.execute(
-            'INSERT INTO main_resourcemedia (resource_id, media_id, project_id) SELECT "main_resource".id, "main_media".id, "main_media".project FROM main_resource_media LEFT OUTER JOIN "main_media" ON ("main_resource_media"."media_id" = "main_media"."id") LEFT OUTER JOIN "main_resource" ON ("main_resource_media"."resource_id" = "main_resource"."id")'
+            'INSERT INTO main_resourcemedia (resource_id, media_id, project_id) SELECT resource_id, "main_media".id, "main_media".project FROM main_resource_media LEFT OUTER JOIN "main_media" ON ("main_resource_media"."media_id" = "main_media"."id")'
         )

--- a/api/main/util.py
+++ b/api/main/util.py
@@ -1419,3 +1419,10 @@ def migrate_old_many_to_many():
         cursor.execute(
             'INSERT INTO main_resourcemediam2m (resource_id, media_id, project_id) SELECT resource_id, "main_media".id, "main_media".project FROM main_resource_media LEFT OUTER JOIN "main_media" ON ("main_resource_media"."media_id" = "main_media"."id")'
         )
+
+        # Now sections
+        # Handle resource many to many first
+        cursor.execute("DELETE FROM main_sectionmediam2m")
+        cursor.execute(
+            'INSERT INTO main_sectionmediam2m (section_id, media_id, project_id) SELECT section_id, "main_media".id, "main_media".project FROM main_section_media LEFT OUTER JOIN "main_media" ON ("main_section_media"."media_id" = "main_media"."id")'
+        )

--- a/api/main/util.py
+++ b/api/main/util.py
@@ -1361,3 +1361,34 @@ def cull_low_used_indices(project_id, dry_run=True, population_limit=10000):
                     continue
                 print(f"Deleting index for {t.name} {attr['name']}/{attr['dtype']}")
                 ts.delete_index(t, attr)
+
+
+def fill_lookup_table(project_id, dry_run=False):
+    unhandled_media = Media.objects.filter(project=project_id, projectlookup__isnull=True)
+    unhandled_localizations = Localization.objects.filter(
+        project=project_id, projectlookup__isnull=True
+    )
+    unhandled_states = State.objects.filter(project=project_id, projectlookup__isnull=True)
+
+    print(
+        "For {project_id}, need to add:\n\t{unhandled_media.count()} media to lookup table\n\t{unhandled_localizations.count()} localizations to lookup table\n\t{unhandled_states.count()} states to lookup table"
+    )
+
+    if dry_run:
+        return
+
+    # Break into 500-element chunks
+    for chunk in unhandled_media.iterator(chunk_size=500):
+        ProjectLookup.objects.bulk_create(
+            [ProjectLookUp(project=project_id, media_id=m.id) for m in chunk]
+        )
+
+    for chunk in unhandled_localizations.iterator(chunk_size=500):
+        ProjectLookup.objects.bulk_create(
+            [ProjectLookUp(project=project_id, localization_id=l.id) for l in chunk]
+        )
+
+    for chunk in unhandled_states.iterator(chunk_size=500):
+        ProjectLookup.objects.bulk_create(
+            [ProjectLookUp(project=project_id, state_id=s.id) for s in chunk]
+        )

--- a/api/main/util.py
+++ b/api/main/util.py
@@ -1415,7 +1415,7 @@ def migrate_old_many_to_many():
 
     with connection.cursor() as cursor:
         # Handle resource many to many first
-        cursor.execute("DELETE FROM main_resourcemedia")
+        cursor.execute("DELETE FROM main_resourcemediam2m")
         cursor.execute(
-            'INSERT INTO main_resourcemedia (resource_id, media_id, project_id) SELECT resource_id, "main_media".id, "main_media".project FROM main_resource_media LEFT OUTER JOIN "main_media" ON ("main_resource_media"."media_id" = "main_media"."id")'
+            'INSERT INTO main_resourcemediam2m (resource_id, media_id, project_id) SELECT resource_id, "main_media".id, "main_media".project FROM main_resource_media LEFT OUTER JOIN "main_media" ON ("main_resource_media"."media_id" = "main_media"."id")'
         )


### PR DESCRIPTION
This PR adds project based access when accessing elements by ID. 

This can occur via individual get accesses in REST (e.g. `/rest/Localization/foo`), Foreign Key relationships, and ManyToMany relationships.

The psuedo-code in any case is
`Object.objects.filter(project=foo, id=baz)` or `Object.object.filter(project=foo,id__in=baz)` vs `Object.objects.filter(id=baz)` or `Object.objects.filter(id__in=baz)`. This was accomplished via adding a ProjectLookup table model which is populated via triggers on editing `Media`, `State`, or `Localization` elements. 

ForeignKeyField usage was replaced with `ForeignObject` usage which incorporates both `project` and `related` in the relationship upon access. 

ManyToManyFields were replaced with new ManyToManyFields which utilize a custom table and multiple through fields. This allows a similar operation to occur such that `project` is used in any lookup between models where-in it is appropriate and performance-oriented.

This PR requires additional migrations which will be backported to `stable`

