### PR TITLE
Fix #1819, Resolve modified_by on delete calls

### DIFF
--- a/api/main/rest/localization.py
+++ b/api/main/rest/localization.py
@@ -261,7 +261,7 @@ class LocalizationListAPI(BaseListView):
                         qs,
                         params["project"],
                         self.request.user,
-                        update_kwargs={"variant_deleted": True},
+                        update_kwargs={"modified_by": self.request.user, "variant_deleted": True},
                         new_attributes=None,
                     )
                 else:
@@ -269,6 +269,7 @@ class LocalizationListAPI(BaseListView):
                     for original in qs.iterator():
                         original.pk = None
                         original.id = None
+                        original.modified_by = self.request.user
                         original.variant_deleted = True
                         objs.append(original)
                     Localization.objects.bulk_create(objs)
@@ -543,6 +544,7 @@ class LocalizationDetailBaseAPI(BaseDetailView):
             b = qs[0]
             b.pk = None
             b.variant_deleted = True
+            b.modified_by = self.request.user
             b.save()
             obj_id = b.id
             log_changes(b, b.model_dict, b.project, self.request.user)

--- a/api/main/rest/state.py
+++ b/api/main/rest/state.py
@@ -374,7 +374,7 @@ class StateListAPI(BaseListView):
                         qs,
                         params["project"],
                         self.request.user,
-                        update_kwargs={"variant_deleted": True},
+                        update_kwargs={"variant_deleted": True, "modifed_by": self.request.user},
                         new_attributes=None,
                     )
                 else:
@@ -383,6 +383,7 @@ class StateListAPI(BaseListView):
                         original.pk = None
                         original.id = None
                         original.variant_deleted = True
+                        original.modified_by = self.request.user
                         objs.append(original)
                     State.objects.bulk_create(objs)
 
@@ -630,6 +631,7 @@ class StateDetailBaseAPI(BaseDetailView):
             obj.id = None
             obj.pk = None
             origin_datetime = obj.created_datetime
+            obj.modified_by = self.request.user
             obj.save()
             found_it = State.objects.get(pk=obj.pk)
             # Keep original creation time


### PR DESCRIPTION
This resolves an issue when deleted marks were not modified_by the deleting user. This was cherry-picked from a commit on rc/1.3.14