### PR TITLE
Update legacy bundles to 1.3.16 and include tator.js and tator.min.js

### DIFF
--- a/ui/scripts/download_legacy_bundles.sh
+++ b/ui/scripts/download_legacy_bundles.sh
@@ -1,3 +1,3 @@
 mkdir -p legacy
-wget -O "/tmp/bundles_1-3-12.zip" "https://tator-ci.s3.us-east-1.amazonaws.com/bundles_1-3-12.zip"
-unzip -o "/tmp/bundles_1-3-12.zip" -d "legacy"
+wget -O "/tmp/bundles_1-3-16.zip" "https://tator-ci.s3.us-east-1.amazonaws.com/bundles_1-3-16.zip"
+unzip -o "/tmp/bundles_1-3-16.zip" -d "legacy"


### PR DESCRIPTION
Closes #1873 