### PR TITLE
Resolve #1900, Serialize permission mask in REST responses

### DIFF
--- a/api/main/_get_and_render.py
+++ b/api/main/_get_and_render.py
@@ -1,6 +1,7 @@
 import jinja2
 import requests
 
+
 def to_dict(param_list):
     return {p["name"]: p["value"] for p in param_list}
 
@@ -12,5 +13,3 @@ def get_and_render(ht, reg):
     template = jinja2.Template(response.text)
     rendered_string = template.render(tparams)
     return rendered_string
-
-

--- a/api/main/_permission_util.py
+++ b/api/main/_permission_util.py
@@ -208,7 +208,7 @@ def augment_permission(user, qs):
             assert False, f"Unhandled model {model} (no permission logic for org/project)"
     else:
         # If an object doesn't exist, we can't annotate it
-        return qs
+        return qs.annotate(effective_permission=Value(0))
 
     if qs.query.low_mark != 0 or qs.query.high_mark is not None:
         # This is a slice, we need to get the full queryset to annotate + filter

--- a/api/main/kube.py
+++ b/api/main/kube.py
@@ -135,8 +135,7 @@ def _get_api(cluster):
 
 
 def _get_clusters(project):
-    """Get unique clusters for the given project.
-    """
+    """Get unique clusters for the given project."""
     algos = Algorithm.objects.all()
     if project is not None:
         algos = algos.filter(project=project)

--- a/api/main/rest/_base_views.py
+++ b/api/main/rest/_base_views.py
@@ -102,7 +102,14 @@ class TatorAPIView(APIView):
     def filter_only_viewables(self, qs, required_mask=PermissionMask.EXIST | PermissionMask.READ):
         # Convenience function for filtering out objects for most views
         if os.getenv("TATOR_FINE_GRAIN_PERMISSION", None) == "true":
-            qs = augment_permission(self.request.user, qs)
+            user = self.request.user
+            if isinstance(self.request.user, AnonymousUser):
+                anonymous_qs = User.objects.filter(username="anonymous")
+                if anonymous_qs.exists():
+                    user = anonymous_qs[0]
+                else:
+                    return qs.none()
+            qs = augment_permission(user, qs)
             if qs.exists():
                 qs = qs.annotate(is_viewable=ColBitAnd(F("effective_permission"), required_mask))
                 qs = qs.filter(is_viewable__exact=required_mask)

--- a/api/main/rest/_base_views.py
+++ b/api/main/rest/_base_views.py
@@ -117,7 +117,8 @@ class TatorAPIView(APIView):
                         qs = qs.order_by("name", "id")
                     else:
                         qs = qs.order_by("id")
-
+        else:
+            qs = qs.annotate(effective_permission=Value(0))
         return qs
 
 

--- a/api/main/rest/_fine_grain_permissions.py
+++ b/api/main/rest/_fine_grain_permissions.py
@@ -423,7 +423,11 @@ class OrganizationPermissionBase(BasePermission):
             organization = get_object_or_404(Organization, pk=int(organization_id))
         elif "id" in view.kwargs:
             pk = view.kwargs["id"]
-            obj = get_object_or_404(view.get_queryset(), pk=pk)
+            qs = view.get_queryset()
+            if qs.exists():
+                obj = qs[0]
+            else:
+                raise PermissionDenied
             organization = self._organization_from_object(obj)
             if organization is None:
                 raise Http404

--- a/api/main/rest/_job.py
+++ b/api/main/rest/_job.py
@@ -4,11 +4,13 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 def _job_media_ids(job):
     parameters = job["spec"]["arguments"]["parameters"]
     for param in parameters:
         if param["name"] == "media_ids":
             return [int(media_id) for media_id in param["value"].split(",")]
+
 
 def _job_project(job):
     parameters = job["spec"]["arguments"]["parameters"]

--- a/api/main/rest/bucket.py
+++ b/api/main/rest/bucket.py
@@ -53,13 +53,14 @@ class BucketListAPI(BaseListView):
 
     def _get(self, params):
         # Make sure user has access to this organization.
-        affiliation = Affiliation.objects.filter(
-            organization=params["organization"], user=self.request.user
-        )
-        if affiliation.count() == 0:
-            raise PermissionDenied
-        if affiliation[0].permission != "Admin":
-            raise PermissionDenied
+        if os.getenv("TATOR_FINE_GRAINED_PERMISSION", "False") != "True":
+            affiliation = Affiliation.objects.filter(
+                organization=params["organization"], user=self.request.user
+            )
+            if affiliation.count() == 0:
+                raise PermissionDenied
+            if affiliation[0].permission != "Admin":
+                raise PermissionDenied
         buckets = self.get_queryset()
         return [serialize_bucket(bucket) for bucket in buckets]
 

--- a/api/main/rest/bucket.py
+++ b/api/main/rest/bucket.py
@@ -20,6 +20,7 @@ from ._permissions import OrganizationEditPermission
 
 logger = logging.getLogger(__name__)
 
+
 def _get_endpoint_url(bucket):
     if bucket.store_type == ObjectStore.GCP:
         return None

--- a/api/main/rest/bucket.py
+++ b/api/main/rest/bucket.py
@@ -95,7 +95,7 @@ class BucketDetailAPI(BaseDetailView):
     def _get(self, params):
         # Make sure bucket exists.
         buckets = self.get_queryset()
-        if buckets.count() == 0:
+        if buckets.exists() == False:
             raise Http404
 
         if os.getenv("TATOR_FINE_GRAINED_PERMISSION", "False") != "True":

--- a/api/main/rest/bucket.py
+++ b/api/main/rest/bucket.py
@@ -53,7 +53,7 @@ class BucketListAPI(BaseListView):
 
     def _get(self, params):
         # Make sure user has access to this organization.
-        if os.getenv("TATOR_FINE_GRAINED_PERMISSION", "False") != "True":
+        if os.getenv("TATOR_FINE_GRAIN_PERMISSION", "False") != "true":
             affiliation = Affiliation.objects.filter(
                 organization=params["organization"], user=self.request.user
             )
@@ -98,7 +98,7 @@ class BucketDetailAPI(BaseDetailView):
         if buckets.exists() == False:
             raise Http404
 
-        if os.getenv("TATOR_FINE_GRAINED_PERMISSION", "False") != "True":
+        if os.getenv("TATOR_FINE_GRAIN_PERMISSION", "False") != "true":
             # Make sure user has access to this organization.
             affiliation = Affiliation.objects.filter(
                 organization=buckets[0].organization, user=self.request.user

--- a/api/main/rest/job.py
+++ b/api/main/rest/job.py
@@ -38,6 +38,7 @@ def media_batches(media_list, files_per_job):
     for i in range(0, len(media_list), files_per_job):
         yield media_list[i : i + files_per_job]
 
+
 class JobListAPI(BaseListView):
     """Interact with list of background jobs."""
 

--- a/api/main/rest/job_cluster.py
+++ b/api/main/rest/job_cluster.py
@@ -52,7 +52,7 @@ class JobClusterListAPI(BaseListView):
         """
         user = self.request.user
         org_id = params["organization"]
-        if os.getenv("TATOR_FINE_GRAINED_PERMISSION", "False") != "True":
+        if os.getenv("TATOR_FINE_GRAIN_PERMISSION", "False") != "true":
             affiliations = Affiliation.objects.filter(user=user, permission="Admin")
             organization_ids = affiliations.values_list("organization", flat=True)
             if org_id not in organization_ids:
@@ -122,7 +122,7 @@ class JobClusterDetailAPI(BaseDetailView):
         job_cluster_qs = self.get_queryset()
         if job_cluster_qs.exists():
             org_id = job_cluster_qs[0].organization.id
-            if os.getenv("TATOR_FINE_GRAINED_PERMISSION", "False") != "True":
+            if os.getenv("TATOR_FINE_GRAIN_PERMISSION", "False") != "true":
                 affiliations = Affiliation.objects.filter(user=user, permission="Admin")
                 organization_ids = affiliations.values_list("organization", flat=True)
                 if org_id not in organization_ids:

--- a/api/main/rest/job_cluster.py
+++ b/api/main/rest/job_cluster.py
@@ -25,7 +25,16 @@ from ..schema import parse
 logger = logging.getLogger(__name__)
 
 
-JOB_CLUSTER_PROPERTIES = ["id", "name", "organization", "host", "port", "token", "cert"]
+JOB_CLUSTER_PROPERTIES = [
+    "id",
+    "name",
+    "organization",
+    "host",
+    "port",
+    "token",
+    "cert",
+    "effective_permission",
+]
 
 
 class JobClusterListAPI(BaseListView):
@@ -43,12 +52,13 @@ class JobClusterListAPI(BaseListView):
         """
         user = self.request.user
         org_id = params["organization"]
-        affiliations = Affiliation.objects.filter(user=user, permission="Admin")
-        organization_ids = affiliations.values_list("organization", flat=True)
-        if org_id not in organization_ids:
-            raise PermissionDenied(
-                f"User {user} does not have Admin permissions for organization {org_id}"
-            )
+        if os.getenv("TATOR_FINE_GRAINED_PERMISSION", "False") != "True":
+            affiliations = Affiliation.objects.filter(user=user, permission="Admin")
+            organization_ids = affiliations.values_list("organization", flat=True)
+            if org_id not in organization_ids:
+                raise PermissionDenied(
+                    f"User {user} does not have Admin permissions for organization {org_id}"
+                )
         return list(self.get_queryset().values(*JOB_CLUSTER_PROPERTIES))
 
     def get_queryset(self, **kwargs):
@@ -109,15 +119,17 @@ class JobClusterDetailAPI(BaseDetailView):
     def _get(self, params):
         """Retrieve the requested algortihm entry by ID"""
         user = self.request.user
-        job_cluster = self.get_queryset().first()
-        org_id = job_cluster.organization.id
-        affiliations = Affiliation.objects.filter(user=user, permission="Admin")
-        organization_ids = affiliations.values_list("organization", flat=True)
-        if org_id not in organization_ids:
-            raise PermissionDenied(
-                f"User {user} does not have Admin permissions for organization {org_id}"
-            )
-        return model_to_dict(job_cluster, fields=["id", "name", "host", "port", "token", "cert"])
+        job_cluster_qs = self.get_queryset()
+        if job_cluster_qs.exists():
+            org_id = job_cluster_qs[0].organization.id
+            if os.getenv("TATOR_FINE_GRAINED_PERMISSION", "False") != "True":
+                affiliations = Affiliation.objects.filter(user=user, permission="Admin")
+                organization_ids = affiliations.values_list("organization", flat=True)
+                if org_id not in organization_ids:
+                    raise PermissionDenied(
+                        f"User {user} does not have Admin permissions for organization {org_id}"
+                    )
+        return job_cluster_qs.values(*JOB_CLUSTER_PROPERTIES)[0]
 
     @transaction.atomic
     def _patch(self, params) -> dict:

--- a/api/main/rest/localization.py
+++ b/api/main/rest/localization.py
@@ -16,6 +16,8 @@ from ..schema import LocalizationListSchema
 from ..schema import LocalizationDetailSchema, LocalizationByElementalIdSchema
 from ..schema.components import localization as localization_schema
 
+from .._permission_util import augment_permission
+
 from ._base_views import BaseListView
 from ._base_views import BaseDetailView
 from ._annotation_query import get_annotation_queryset
@@ -519,7 +521,9 @@ class LocalizationDetailBaseAPI(BaseDetailView):
 
         return {
             "message": f"Localization {obj.elemental_id}@{obj.version.id}/{obj.mark} successfully updated!",
-            "object": type(obj).objects.filter(pk=obj.pk).values(*LOCALIZATION_PROPERTIES)[0],
+            "object": augment_permission(
+                self.request.user, type(obj).objects.filter(pk=obj.pk)
+            ).values(*LOCALIZATION_PROPERTIES)[0],
         }
 
     def delete_qs(self, params, qs):

--- a/api/main/rest/localization_type.py
+++ b/api/main/rest/localization_type.py
@@ -35,6 +35,7 @@ fields = [
     "drawable",
     "grouping_default",
     "elemental_id",
+    "effective_permission",
 ]
 
 

--- a/api/main/rest/media.py
+++ b/api/main/rest/media.py
@@ -922,4 +922,4 @@ class MediaDetailAPI(BaseDetailView):
         return {"message": f'Media {params["id"]} successfully deleted!'}
 
     def get_queryset(self, **kwargs):
-        return Media.objects.filter(pk=self.params["id"], deleted=False)
+        return self.filter_only_viewables(Media.objects.filter(pk=self.params["id"], deleted=False))

--- a/api/main/rest/media.py
+++ b/api/main/rest/media.py
@@ -469,7 +469,7 @@ class MediaListAPI(BaseListView):
                 project, media_spec_list[0], self.request.user, use_rq=True
             )
             qs = Media.objects.filter(id=obj.id)
-            response_data = list(qs.values(*fields))
+            response_data = list(augment_permission(self.request.user, qs).values(*fields))
             response_data = response_data if received_spec_list else response_data[0]
             id_resp = [obj.id] if received_spec_list else obj.id
             response = {"message": msg, "id": id_resp, "object": response_data}
@@ -488,7 +488,7 @@ class MediaListAPI(BaseListView):
                     ids.append(obj.id)
 
             qs = Media.objects.filter(id__in=set(ids))
-            response_data = list(qs.values(*fields))
+            response_data = list(augment_permission(self.request.user, qs).values(*fields))
             response = {
                 "message": f"Started import of {len(ids)} images!",
                 "id": ids,

--- a/api/main/rest/media_type.py
+++ b/api/main/rest/media_type.py
@@ -37,6 +37,7 @@ fields = [
     "default_line",
     "default_dot",
     "elemental_id",
+    "effective_permission"
 ]
 
 

--- a/api/main/rest/media_type.py
+++ b/api/main/rest/media_type.py
@@ -37,7 +37,7 @@ fields = [
     "default_line",
     "default_dot",
     "elemental_id",
-    "effective_permission"
+    "effective_permission",
 ]
 
 

--- a/api/main/rest/organization.py
+++ b/api/main/rest/organization.py
@@ -4,9 +4,10 @@ from rest_framework.exceptions import PermissionDenied
 from django.db import transaction
 
 from ..cache import TatorCache
-from ..models import Affiliation, database_qs, Organization, Permission, safe_delete, RowProtection
+from ..models import Affiliation, Organization, Permission, safe_delete, RowProtection
 from ..schema import OrganizationListSchema
 from ..schema import OrganizationDetailSchema
+from ..schema.components.organization import organization
 from ..store import get_tator_store
 
 from ._permissions import OrganizationAdminPermission, OrganizationMemberPermission
@@ -19,10 +20,12 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+ORGANIZATION_KEYS = list(organization["properties"].keys())
+ORGANIZATION_KEYS.remove("permission")
 
 def _serialize_organizations(organizations, user_id):
     ttl = 28800
-    organization_data = database_qs(organizations)
+    organization_data = list(organizations.values(*ORGANIZATION_KEYS))
     store = get_tator_store()
     cache = TatorCache()
     for idx, organization in enumerate(organizations):
@@ -118,7 +121,7 @@ class OrganizationDetailAPI(BaseDetailView):
         return super().get_permissions()
 
     def _get(self, params):
-        organizations = Organization.objects.filter(pk=params["id"])
+        organizations = self.get_queryset()
         return _serialize_organizations(organizations, self.request.user.pk)[0]
 
     @transaction.atomic

--- a/api/main/rest/organization.py
+++ b/api/main/rest/organization.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 ORGANIZATION_KEYS = list(organization["properties"].keys())
 ORGANIZATION_KEYS.remove("permission")
 
+
 def _serialize_organizations(organizations, user_id):
     ttl = 28800
     organization_data = list(organizations.values(*ORGANIZATION_KEYS))

--- a/api/main/rest/permalink.py
+++ b/api/main/rest/permalink.py
@@ -101,7 +101,7 @@ class PermalinkAPI(TatorAPIView):
         A media may be an image or a video. Media are a type of entity in Tator,
         meaning they can be described by user defined attributes.
         """
-        qs = Media.objects.filter(pk=params["id"], deleted=False)
+        qs = self.get_queryset()
         if not qs.exists():
             raise Http404
         fields = [*MEDIA_PROPERTIES]
@@ -149,4 +149,6 @@ class PermalinkAPI(TatorAPIView):
         return process_exception(exc)
 
     def get_queryset(self):
-        return Media.objects.all()
+        media_qs = Media.objects.filter(pk=self.params["id"], deleted=False)
+        print(f"media_qs: {media_qs}")
+        return self.filter_only_viewables(media_qs)

--- a/api/main/rest/project.py
+++ b/api/main/rest/project.py
@@ -55,8 +55,6 @@ def _serialize_projects(projects, user_id):
     ttl = 28800
     project_data = list(projects.values(*PROJECT_PROPERTIES))
     stores = {None: get_tator_store(None, connect_timeout=1, read_timeout=1, max_attempts=1)}
-    if os.getenv("TATOR_FINE_GRAIN_PERMISSION", None) == "true":
-        projects = augment_permission(User.objects.get(pk=user_id), projects)
 
     for idx, project in enumerate(projects):
         if os.getenv("TATOR_FINE_GRAIN_PERMISSION", None) == "true":
@@ -266,7 +264,7 @@ class ProjectDetailAPI(BaseDetailView):
         return super().get_permissions()
 
     def _get(self, params):
-        projects = Project.objects.filter(pk=params["id"])
+        projects = self.get_queryset()
         return _serialize_projects(projects, self.request.user.pk)[0]
 
     @transaction.atomic

--- a/api/main/rest/project.py
+++ b/api/main/rest/project.py
@@ -225,7 +225,7 @@ class ProjectListAPI(BaseListView):
             )
         member.save()
 
-        projects = Project.objects.filter(pk=project.id)
+        projects = self.get_queryset().filter(pk=project.pk)
         return {
             "message": f"Project {params['name']} created!",
             "id": project.id,
@@ -349,7 +349,7 @@ class ProjectDetailAPI(BaseDetailView):
         else:
             raise ValueError(f"No recognized keys in request!")
 
-        projects = Project.objects.filter(pk=project.id)
+        projects = self.get_queryset()
         return {
             "message": f"Project {params['id']} updated successfully!",
             "object": _serialize_projects(projects, self.request.user.pk)[0],

--- a/api/main/rest/rowprotection.py
+++ b/api/main/rest/rowprotection.py
@@ -102,15 +102,15 @@ class RowProtectionListAPI(BaseListView):
         filters = [x["name"] for x in search_filters]
         for key in self.params.keys():
             if key in filters and self.params.get(key, None):
+                logger.info(f"Filtering on {key} with {self.params[key]}")
                 qs = qs.filter(**{key: self.params[key]})
 
+        ids_user_can_see = []
         for row_protection in qs:
-            if check_acl_permission_of_children(self.request.user, row_protection) is False:
-                raise PermissionDenied(
-                    "User does not have permission to acccess this row protection set"
-                )
+            if check_acl_permission_of_children(self.request.user, row_protection) is True:
+                ids_user_can_see.append(row_protection.id)
 
-        return qs
+        return RowProtection.objects.filter(pk__in=ids_user_can_see)
 
     def _delete(self, params: dict) -> dict:
         qs = self.get_queryset()

--- a/api/main/rest/state.py
+++ b/api/main/rest/state.py
@@ -26,6 +26,7 @@ from ..schema import MergeStatesSchema
 from ..schema import TrimStateEndSchema
 from ..schema.components import state as state_schema
 
+from .._permission_util import augment_permission
 from ._base_views import BaseListView
 from ._base_views import BaseDetailView
 from ._annotation_query import get_annotation_queryset
@@ -642,7 +643,9 @@ class StateDetailBaseAPI(BaseDetailView):
 
         return {
             "message": f"State {obj.elemental_id}@{obj.version.id}/{obj.mark} successfully updated!",
-            "object": type(obj).objects.filter(pk=obj.pk).values(*STATE_PROPERTIES)[0],
+            "object": augment_permission(
+                self.request.user, type(obj).objects.filter(pk=obj.pk)
+            ).values(*STATE_PROPERTIES)[0],
         }
 
     def delete_qs(self, params, qs):

--- a/api/main/rest/state.py
+++ b/api/main/rest/state.py
@@ -710,9 +710,6 @@ class StateDetailBaseAPI(BaseDetailView):
             "id": obj_id,
         }
 
-    def get_queryset(self):
-        return State.objects.all()
-
 
 class MergeStatesAPI(BaseDetailView):
     """#TODO"""
@@ -865,7 +862,7 @@ class StateDetailByElementalIdAPI(StateDetailBaseAPI):
         else:
             latest_mark = qs.aggregate(value=Max("mark"))
             qs = qs.filter(mark=latest_mark["value"])
-        return qs
+        return self.filter_only_viewables(qs)
 
     def _get(self, params):
         return self.get_qs(params, self.get_queryset())

--- a/api/main/rest/state_type.py
+++ b/api/main/rest/state_type.py
@@ -31,6 +31,7 @@ fields = [
     "delete_child_localizations",
     "default_localization",
     "elemental_id",
+    "effective_permission"
 ]
 
 import logging

--- a/api/main/rest/state_type.py
+++ b/api/main/rest/state_type.py
@@ -31,7 +31,7 @@ fields = [
     "delete_child_localizations",
     "default_localization",
     "elemental_id",
-    "effective_permission"
+    "effective_permission",
 ]
 
 import logging

--- a/api/main/rest/state_type.py
+++ b/api/main/rest/state_type.py
@@ -79,7 +79,7 @@ class StateTypeListAPI(BaseListView):
         if elemental_id is not None:
             safe = uuid.UUID(elemental_id)
             qs = qs.filter(elemental_id=safe)
-        return qs
+        return self.filter_only_viewables(qs)
 
     def _get(self, params):
         """Retrieve state types.
@@ -231,4 +231,4 @@ class StateTypeDetailAPI(BaseDetailView):
         }
 
     def get_queryset(self, **kwargs):
-        return StateType.objects.filter(pk=self.params["id"])
+        return self.filter_only_viewables(StateType.objects.filter(pk=self.params["id"]))

--- a/api/main/schema/components/bucket.py
+++ b/api/main/schema/components/bucket.py
@@ -68,8 +68,8 @@ bucket_properties = {
     "external_host": {"description": "The proxy host for presigned urls.", "type": "string"},
     "effective_permission": {
         "type": "integer",
-        "description": "Effective permission mask for this entity."
-    }
+        "description": "Effective permission mask for this entity.",
+    },
 }
 
 all_bucket_properties = {

--- a/api/main/schema/components/bucket.py
+++ b/api/main/schema/components/bucket.py
@@ -66,6 +66,10 @@ bucket_properties = {
         "enum": ["AWS", "MINIO", "GCP", "OCI", "VAST"],
     },
     "external_host": {"description": "The proxy host for presigned urls.", "type": "string"},
+    "effective_permission": {
+        "type": "integer",
+        "description": "Effective permission mask for this entity."
+    }
 }
 
 all_bucket_properties = {

--- a/api/main/schema/components/hosted_template.py
+++ b/api/main/schema/components/hosted_template.py
@@ -58,6 +58,10 @@ hosted_template = {
             "type": "integer",
             "description": "Unique integer identifying the organization associated with the hosted template.",
         },
+        "effective_permission": {
+            "type": "integer",
+            "description": "Effective permission mask for this entity.",
+        },
         # Headers are excluded from GET requests.
         **{k: v for k, v in hosted_template_post_properties.items() if k != "headers"},
     },

--- a/api/main/schema/components/job_cluster.py
+++ b/api/main/schema/components/job_cluster.py
@@ -42,6 +42,10 @@ job_cluster = {
             "type": "integer",
             "description": "Unique integer identifying the organization associated with the job cluster.",
         },
+        "effective_permission": {
+            "type": "integer",
+            "description": "Effective permission mask for this entity.",
+        },
         **job_cluster_post_properties,
     },
 }

--- a/api/main/schema/components/localization.py
+++ b/api/main/schema/components/localization.py
@@ -154,7 +154,7 @@ localization_get_properties = {
     "effective_permission": {
         "type": "integer",
         "description": "Effective permission mask for the current user.",
-    }
+    },
 }
 
 localization_spec = {

--- a/api/main/schema/components/localization.py
+++ b/api/main/schema/components/localization.py
@@ -151,6 +151,10 @@ localization_get_properties = {
         "type": "boolean",
         "description": "Unique integer identifying the user who created this localization.",
     },
+    "effective_permission": {
+        "type": "integer",
+        "description": "Effective permission mask for the current user.",
+    }
 }
 
 localization_spec = {

--- a/api/main/schema/components/localization_type.py
+++ b/api/main/schema/components/localization_type.py
@@ -43,6 +43,10 @@ localization_type_properties = {
         "type": "string",
         "nullable": True,
     },
+    "effective_permission": {
+        "type": "integer",
+        "description": "Effective permission mask for this entity."
+    }
 }
 
 localization_type_spec = {

--- a/api/main/schema/components/localization_type.py
+++ b/api/main/schema/components/localization_type.py
@@ -45,8 +45,8 @@ localization_type_properties = {
     },
     "effective_permission": {
         "type": "integer",
-        "description": "Effective permission mask for this entity."
-    }
+        "description": "Effective permission mask for this entity.",
+    },
 }
 
 localization_type_spec = {

--- a/api/main/schema/components/media.py
+++ b/api/main/schema/components/media.py
@@ -356,5 +356,10 @@ media = {
             "type": "integer",
             "nullable": True,
         },
+        "effective_permission": {
+            "description": "Calculated permission for this value",
+            "type": "integer",
+            "nullable": True,
+        },
     },
 }

--- a/api/main/schema/components/media_type.py
+++ b/api/main/schema/components/media_type.py
@@ -68,6 +68,10 @@ media_type_properties = {
         "type": "string",
         "nullable": True,
     },
+    "effective_permission": {
+        "type": "integer",
+        "description": "Effective permission mask for this entity."
+    }
 }
 
 media_type_spec = {

--- a/api/main/schema/components/media_type.py
+++ b/api/main/schema/components/media_type.py
@@ -70,8 +70,8 @@ media_type_properties = {
     },
     "effective_permission": {
         "type": "integer",
-        "description": "Effective permission mask for this entity."
-    }
+        "description": "Effective permission mask for this entity.",
+    },
 }
 
 media_type_spec = {

--- a/api/main/schema/components/organization.py
+++ b/api/main/schema/components/organization.py
@@ -23,6 +23,10 @@ organization_properties = {
         "type": "string",
         "description": "S3 key of thumbnail used to represent the organization.",
     },
+    "effective_permission": {
+        "type": "integer",
+        "description": "The effective permission for the user making the request",
+    },
 }
 
 organization_spec = {

--- a/api/main/schema/components/project.py
+++ b/api/main/schema/components/project.py
@@ -38,6 +38,10 @@ project_properties = {
         "type": "string",
         "nullable": True,
     },
+    "effective_permission": {
+        "type": "integer",
+        "description": "Effective permission mask of user making request.",
+    },
 }
 
 project_spec = {

--- a/api/main/schema/components/state.py
+++ b/api/main/schema/components/state.py
@@ -85,7 +85,7 @@ state_get_properties = {
     "effective_permission": {
         "type": "integer",
         "description": "Effective permission mask for the current user.",
-    }
+    },
 }
 
 state_spec = {

--- a/api/main/schema/components/state.py
+++ b/api/main/schema/components/state.py
@@ -82,6 +82,10 @@ state_get_properties = {
         "type": "boolean",
         "description": "Unique integer identifying the user who created this localization.",
     },
+    "effective_permission": {
+        "type": "integer",
+        "description": "Effective permission mask for the current user.",
+    }
 }
 
 state_spec = {

--- a/api/main/schema/components/state_type.py
+++ b/api/main/schema/components/state_type.py
@@ -53,8 +53,8 @@ state_type_properties = {
     },
     "effective_permission": {
         "type": "integer",
-        "description": "Effective permission mask for this entity."
-    }
+        "description": "Effective permission mask for this entity.",
+    },
 }
 
 state_type_spec = {

--- a/api/main/schema/components/state_type.py
+++ b/api/main/schema/components/state_type.py
@@ -51,6 +51,10 @@ state_type_properties = {
         "type": "string",
         "nullable": True,
     },
+    "effective_permission": {
+        "type": "integer",
+        "description": "Effective permission mask for this entity."
+    }
 }
 
 state_type_spec = {

--- a/api/main/schema/components/version.py
+++ b/api/main/schema/components/version.py
@@ -54,6 +54,6 @@ version = {
         "effective_permission": {
             "type": "integer",
             "description": "Effective permission mask for this user.",
-        }
+        },
     },
 }

--- a/api/main/schema/components/version.py
+++ b/api/main/schema/components/version.py
@@ -51,5 +51,9 @@ version = {
             "type": "string",
             "description": "Name of user who created the last unmodified annotation in this version.",
         },
+        "effective_permission": {
+            "type": "integer",
+            "description": "Effective permission mask for this user.",
+        }
     },
 }

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -7270,7 +7270,8 @@ if os.getenv("TATOR_FINE_GRAIN_PERMISSION") == "true":
             # Verify behavior if you are Captain Kirk
             self.client.force_authenticate(user=self.kirk)
             resp = self.client.get(f"/rest/RowProtections?target_organization={self.starfleet.pk}")
-            assertResponse(self, resp, status.HTTP_403_FORBIDDEN)
+            assert len(resp.data) == 0
+            assertResponse(self, resp, status.HTTP_200_OK)
 
             # The commandant, who didn't steal the klingon ship and get demoted can see all row permissions
             self.client.force_authenticate(user=self.commandant)
@@ -7394,7 +7395,8 @@ if os.getenv("TATOR_FINE_GRAIN_PERMISSION") == "true":
 
             # redshirt cannot get row protections for engineering
             resp = self.client.get(f"/rest/RowProtections?section={section_id}")
-            assertResponse(self, resp, status.HTTP_403_FORBIDDEN)
+            assert len(resp.data) == 0
+            assertResponse(self, resp, status.HTTP_200_OK)
 
             # Go back to kirk
             self.client.force_authenticate(user=self.kirk)

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -6124,7 +6124,9 @@ class JobClusterTestCase(
         assertResponse(self, response, status.HTTP_200_OK)
 
 
-class HostedTemplateTestCase(TatorTransactionTest):
+class HostedTemplateTestCase(
+    TatorTransactionTest, PermissionListAffiliationTestMixin, PermissionDetailAffiliationTestMixin
+):
     @staticmethod
     def _hosted_template_spec():
         uid = str(uuid1())
@@ -6157,48 +6159,10 @@ class HostedTemplateTestCase(TatorTransactionTest):
         response = self.client.get(url)
         assertResponse(self, response, status.HTTP_200_OK)
 
-    def test_list_no_affiliation_permissions(self):
-        affiliation = self.get_affiliation(self.organization, self.user)
-        affiliation.delete()
-        url = f"/rest/{self.list_uri}/{self.organization.pk}"
-        response = self.client.get(url)
-        assertResponse(self, response, status.HTTP_403_FORBIDDEN)
-        affiliation.save()
-
-    def test_list_is_a_member_permissions(self):
-        affiliation = self.get_affiliation(self.organization, self.user)
-        old_permission = affiliation.permission
-        affiliation.permission = "Member"
-        affiliation.save()
-        url = f"/rest/{self.list_uri}/{self.organization.pk}"
-        response = self.client.get(url)
-        assertResponse(self, response, status.HTTP_403_FORBIDDEN)
-        affiliation.permission = old_permission
-        affiliation.save()
-
     def test_detail_is_an_admin_permissions(self):
         url = f"/rest/{self.detail_uri}/{self.entity.pk}"
         response = self.client.get(url)
         assertResponse(self, response, status.HTTP_200_OK)
-
-    def test_detail_no_affiliation_permissions(self):
-        affiliation = self.get_affiliation(self.organization, self.user)
-        affiliation.delete()
-        url = f"/rest/{self.detail_uri}/{self.entity.pk}"
-        response = self.client.get(url)
-        assertResponse(self, response, status.HTTP_403_FORBIDDEN)
-        affiliation.save()
-
-    def test_detail_is_a_member_permissions(self):
-        affiliation = self.get_affiliation(self.organization, self.user)
-        old_permission = affiliation.permission
-        affiliation.permission = "Member"
-        affiliation.save()
-        url = f"/rest/{self.detail_uri}/{self.entity.pk}"
-        response = self.client.get(url)
-        assertResponse(self, response, status.HTTP_403_FORBIDDEN)
-        affiliation.permission = old_permission
-        affiliation.save()
 
 
 class UsernameTestCase(TatorTransactionTest):

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -2500,6 +2500,7 @@ class AnonymousAccessTestCase(TatorTransactionTest):
             RowProtection.objects.create(
                 project=self.private_project, group=internal, permission=PermissionMask.OLD_READ
             ).save()
+
     def test_random_user(self):
         """A random user should get access to public project but not the private project"""
         self.client.force_authenticate(self.random_user)
@@ -7508,7 +7509,6 @@ if os.getenv("TATOR_FINE_GRAIN_PERMISSION") == "true":
             rp = RowProtection.objects.get(pk=rp_id)
             self.assertEqual(rp.permission, 0)
 
-     
             # Now switch to the commandant and verify there is no permission
             self.client.force_authenticate(user=self.commandant)
             resp = self.client.get(f"/rest/Medias/{self.project.pk}")

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -4916,7 +4916,7 @@ class BucketTestCase(
 ):
     def setUp(self):
         print(f"\n{self.__class__.__name__}=", end="", flush=True)
-        logging.disable(logging.CRITICAL)
+        # logging.disable(logging.CRITICAL)
         self.user = create_test_user()
         self.client.force_authenticate(self.user)
         self.organization = create_test_organization()
@@ -6150,9 +6150,19 @@ class HostedTemplateTestCase(
         self.list_uri = "HostedTemplates"
         self.detail_uri = "HostedTemplate"
         self.create_json = self._hosted_template_spec()
+        self.patch_json = {
+            "name": "Updated name",
+            "url": "https://raw.githubusercontent.com/cvisionai/tator/main/doc/examples/workflow_template/echo.yaml",
+        }
         self.entity = HostedTemplate(organization=self.organization, **self.create_json)
         self.entity.save()
+        self.another_one = HostedTemplate(organization=self.organization, **self.create_json)
+        self.another_one.save()
+        self.entities = [self.entity, self.another_one]
         affiliations_to_rowp(self.organization.pk, force=False, verbose=False)
+
+    def get_organization(self):
+        return self.organization
 
     def test_list_is_an_admin_permissions(self):
         url = f"/rest/{self.list_uri}/{self.organization.pk}"

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -6082,7 +6082,9 @@ class MutateAliasTestCase(TatorTransactionTest):
     # TODO: write totally different test for geopos mutations (not supported in query string queries)
 
 
-class JobClusterTestCase(TatorTransactionTest):
+class JobClusterTestCase(
+    TatorTransactionTest, PermissionListAffiliationTestMixin, PermissionDetailAffiliationTestMixin
+):
     @staticmethod
     def _random_job_cluster_spec():
         uid = str(uuid1())
@@ -6116,48 +6118,10 @@ class JobClusterTestCase(TatorTransactionTest):
         response = self.client.get(url)
         assertResponse(self, response, status.HTTP_200_OK)
 
-    def test_list_no_affiliation_permissions(self):
-        affiliation = self.get_affiliation(self.organization, self.user)
-        affiliation.delete()
-        url = f"/rest/{self.list_uri}/{self.organization.pk}"
-        response = self.client.get(url)
-        assertResponse(self, response, status.HTTP_403_FORBIDDEN)
-        affiliation.save()
-
-    def test_list_is_a_member_permissions(self):
-        affiliation = self.get_affiliation(self.organization, self.user)
-        old_permission = affiliation.permission
-        affiliation.permission = "Member"
-        affiliation.save()
-        url = f"/rest/{self.list_uri}/{self.organization.pk}"
-        response = self.client.get(url)
-        assertResponse(self, response, status.HTTP_403_FORBIDDEN)
-        affiliation.permission = old_permission
-        affiliation.save()
-
     def test_detail_is_an_admin_permissions(self):
         url = f"/rest/{self.detail_uri}/{self.entity.pk}"
         response = self.client.get(url)
         assertResponse(self, response, status.HTTP_200_OK)
-
-    def test_detail_no_affiliation_permissions(self):
-        affiliation = self.get_affiliation(self.organization, self.user)
-        affiliation.delete()
-        url = f"/rest/{self.detail_uri}/{self.entity.pk}"
-        response = self.client.get(url)
-        assertResponse(self, response, status.HTTP_403_FORBIDDEN)
-        affiliation.save()
-
-    def test_detail_is_a_member_permissions(self):
-        affiliation = self.get_affiliation(self.organization, self.user)
-        old_permission = affiliation.permission
-        affiliation.permission = "Member"
-        affiliation.save()
-        url = f"/rest/{self.detail_uri}/{self.entity.pk}"
-        response = self.client.get(url)
-        assertResponse(self, response, status.HTTP_403_FORBIDDEN)
-        affiliation.permission = old_permission
-        affiliation.save()
 
 
 class HostedTemplateTestCase(TatorTransactionTest):

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -6133,6 +6133,8 @@ class JobClusterTestCase(
         self.entity.save()
         self.another_one.save()
         self.entities = [self.entity, self.another_one]
+        self.edit_permission = "Admin"
+        self.get_requires_admin = True
         affiliations_to_rowp(self.organization.pk, force=False, verbose=False)
 
     def get_organization(self):
@@ -6184,6 +6186,8 @@ class HostedTemplateTestCase(
         self.another_one = HostedTemplate(organization=self.organization, **self.create_json)
         self.another_one.save()
         self.entities = [self.entity, self.another_one]
+        self.edit_permission = "Admin"
+        self.get_requires_admin = True
         affiliations_to_rowp(self.organization.pk, force=False, verbose=False)
 
     def get_organization(self):

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -2483,6 +2483,23 @@ class AnonymousAccessTestCase(TatorTransactionTest):
         resource.media.add(self.private_video)
         resource.save()
 
+        if os.getenv("TATOR_FINE_GRAIN_PERMISSION", 0) == "true":
+            everyone = Group.objects.create(name="everyone")
+            everyone.save()
+            GroupMembership.objects.create(user=self.anonymous_user, group=everyone).save()
+            GroupMembership.objects.create(user=self.user, group=everyone).save()
+            GroupMembership.objects.create(user=self.random_user, group=everyone).save()
+
+            internal = Group.objects.create(name="internal")
+            internal.save()
+            GroupMembership.objects.create(user=self.user, group=internal).save()
+
+            RowProtection.objects.create(
+                project=self.public_project, group=everyone, permission=PermissionMask.OLD_READ
+            ).save()
+            RowProtection.objects.create(
+                project=self.private_project, group=internal, permission=PermissionMask.OLD_READ
+            ).save()
     def test_random_user(self):
         """A random user should get access to public project but not the private project"""
         self.client.force_authenticate(self.random_user)

--- a/api/main/tests.py
+++ b/api/main/tests.py
@@ -6109,9 +6109,16 @@ class JobClusterTestCase(
         self.list_uri = "JobClusters"
         self.detail_uri = "JobCluster"
         self.create_json = self._random_job_cluster_spec()
+        self.patch_json = self._random_job_cluster_spec()
         self.entity = JobCluster(organization=self.organization, **self.create_json)
+        self.another_one = JobCluster(organization=self.organization, **self.create_json)
         self.entity.save()
+        self.another_one.save()
+        self.entities = [self.entity, self.another_one]
         affiliations_to_rowp(self.organization.pk, force=False, verbose=False)
+
+    def get_organization(self):
+        return self.organization
 
     def test_list_is_an_admin_permissions(self):
         url = f"/rest/{self.list_uri}/{self.organization.pk}"


### PR DESCRIPTION
When fetching Projects, Organizations, Media, Metadata, Version, JobClusters, Buckets, or Hosted Templates append the calculated permission value. This could help in-form UI choices akin to being suggested in #1901 