### PR TITLE
Fixes #1879, adds blob type to attribute manipulation page

### DIFF
--- a/ui/src/js/project-settings/attributes/attributes-form.js
+++ b/ui/src/js/project-settings/attributes/attributes-form.js
@@ -934,7 +934,7 @@ export class AttributesForm extends TatorElement {
 
         if (defaultVal !== null && defaultVal !== "null") {
           // backend does this but not when value is ""
-          if (dtype == "int" || dtype == "float") {
+          if (dtype == "int" || dtype == "float" || dtype == "blob" || dtype == "string") {
             if (String(defaultVal).trim() === "") {
               delete formData["default"];
             } else {

--- a/ui/src/js/project-settings/attributes/attributes-form.js
+++ b/ui/src/js/project-settings/attributes/attributes-form.js
@@ -787,7 +787,7 @@ export class AttributesForm extends TatorElement {
         "fully-reversible": [],
         "reversible-with-warning": [],
         irreversible: [],
-      }
+      },
     };
   }
 
@@ -934,7 +934,12 @@ export class AttributesForm extends TatorElement {
 
         if (defaultVal !== null && defaultVal !== "null") {
           // backend does this but not when value is ""
-          if (dtype == "int" || dtype == "float" || dtype == "blob" || dtype == "string") {
+          if (
+            dtype == "int" ||
+            dtype == "float" ||
+            dtype == "blob" ||
+            dtype == "string"
+          ) {
             if (String(defaultVal).trim() === "") {
               delete formData["default"];
             } else {

--- a/ui/src/js/project-settings/attributes/attributes-form.js
+++ b/ui/src/js/project-settings/attributes/attributes-form.js
@@ -727,6 +727,7 @@ export class AttributesForm extends TatorElement {
       "string",
       "datetime",
       "geopos",
+      "blob",
     ];
     return this.attributeDTypes;
   }
@@ -781,6 +782,12 @@ export class AttributesForm extends TatorElement {
         "reversible-with-warning": [],
         irreversible: [],
       },
+      blob: {
+        allowed: [],
+        "fully-reversible": [],
+        "reversible-with-warning": [],
+        irreversible: [],
+      }
     };
   }
 


### PR DESCRIPTION
Add blob type to dtype selector

Also fixed bug where a blank default for strings and blobs causes massive db churn on projects with lots of data