### PR TITLE
Dev/seek preview

### DIFF
--- a/test/test_playback.py
+++ b/test/test_playback.py
@@ -87,7 +87,7 @@ def test_playback_accuracy(page_factory, project, count_test):
     canvas = page.query_selector("video-canvas")
     page.wait_for_timeout(10000)
     play_button = page.query_selector("play-button")
-    seek_handle = page.query_selector("seek-bar .range-handle")
+    seek_handle = page.query_selector("seek-bar .annotation-range-handle")
     display_div = page.query_selector("#frame_num_display")
     display_ctrl = page.query_selector("#frame_num_ctrl")
 
@@ -151,7 +151,7 @@ def test_playback_accuracy_multi(page_factory, project, multi_count):
   canvas = page.query_selector_all('video-canvas')
   page.wait_for_timeout(10000)
   play_button = page.query_selector('play-button')
-  seek_handle = page.query_selector('seek-bar .range-handle')
+  seek_handle = page.query_selector('seek-bar .annotation-range-handle')
   display_div = page.query_selector('#frame_num_display')
   display_ctrl = page.query_selector('#frame_num_ctrl')
 
@@ -202,7 +202,7 @@ def test_playback_accuracy_multi_offset(page_factory, project, multi_offset_coun
   canvas = page.query_selector_all('video-canvas')
   page.wait_for_timeout(10000)
   play_button = page.query_selector('play-button')
-  seek_handle = page.query_selector('seek-bar .range-handle')
+  seek_handle = page.query_selector('seek-bar .annotation-range-handle')
   display_div = page.query_selector('#frame_num_display')
   display_ctrl = page.query_selector('#frame_num_ctrl')
 
@@ -252,7 +252,7 @@ def test_small_res_file(page_factory, project, small_video):
   page.wait_for_selector('video-canvas')
   canvas = page.query_selector('video-canvas')
   play_button = page.query_selector('play-button')
-  seek_handle = page.query_selector('seek-bar .range-handle')
+  seek_handle = page.query_selector('seek-bar .annotation-range-handle')
 
   # Wait for hq buffer and verify it is blue
   _wait_for_color(page, canvas, 2, timeout=30, name='seek')
@@ -269,7 +269,7 @@ def test_buffer_usage_single(page_factory, project, rgb_test):
   canvas = page.query_selector('video-canvas')
 
   play_button = page.query_selector('play-button')
-  seek_handle = page.query_selector('seek-bar .range-handle')
+  seek_handle = page.query_selector('seek-bar .annotation-range-handle')
 
 
   # Wait for hq buffer and verify it is red
@@ -316,7 +316,7 @@ def test_buffer_usage_multi(page_factory, project, multi_rgb):
     canvas = page.query_selector_all("video-canvas")
     display_ctrl = page.query_selector("#frame_num_ctrl")
     play_button = page.query_selector("play-button")
-    seek_handle = page.query_selector("seek-bar .range-handle")
+    seek_handle = page.query_selector("seek-bar .annotation-range-handle")
 
     # Wait for hq buffer and verify it is red
     print("Waiting 15 seconds for video to load")
@@ -569,7 +569,7 @@ def test_concat(page_factory, project, concat_test):
   canvas = page.query_selector('video-canvas')
 
   play_button = page.query_selector('play-button')
-  seek_handle = page.query_selector('seek-bar .range-handle')
+  seek_handle = page.query_selector('seek-bar .annotation-range-handle')
 
   # Wait for hq buffer and verify it is red
   page.wait_for_timeout(30000)

--- a/ui/src/css/components/annotation.css
+++ b/ui/src/css/components/annotation.css
@@ -699,7 +699,6 @@ annotation-player {
   outline: none;
 }
 
-
 .annotation-range-ondemand {
   -webkit-appearance: none;
   background-color: var(--color-white--25);

--- a/ui/src/css/components/annotation.css
+++ b/ui/src/css/components/annotation.css
@@ -675,12 +675,13 @@ annotation-player {
   margin-top: 0px;
   margin-bottom: 2px;
   position: relative;
+  user-select: none;
 }
 
 .annotation-range-div:focus {
   outline: none;
 }
-.annotation-range-div:hover {
+.annotation-range-div-active {
   height: 5px;
   margin-top: 0px;
   margin-bottom: 0px;

--- a/ui/src/css/components/annotation.css
+++ b/ui/src/css/components/annotation.css
@@ -673,7 +673,7 @@ annotation-player {
   border-radius: 3px;
   height: 3px;
   margin-top: 0px;
-  margin-bottom: 2px;
+  margin-bottom: 7px;
   position: relative;
   user-select: none;
 }
@@ -682,7 +682,7 @@ annotation-player {
   outline: none;
 }
 .annotation-range-div-active {
-  height: 5px;
+  height: 10px;
   margin-top: 0px;
   margin-bottom: 0px;
 }
@@ -709,4 +709,29 @@ annotation-player {
 }
 .annotation-range-ondemand:focus {
   outline: none;
+}
+
+.annotation-range-handle {
+  -webkit-appearance: none;
+  height: 10px;
+  width: 10px;
+  z-index: 1;
+  position: absolute;
+  border-radius: 50%;
+  margin-top: -3.5px;
+  margin-left: -5px;
+  background-color: var(--color-white);
+}
+.annotation-range-handle:focus {
+  outline: none;
+}
+
+.annotation-range-handle-selected {
+  background-color: var(--color-gray--light);
+  border: var(--color-white);
+}
+
+.annotation-range-handle-active {
+  height: 20px;
+  width: 20px;
 }

--- a/ui/src/css/components/annotation.css
+++ b/ui/src/css/components/annotation.css
@@ -667,3 +667,46 @@ annotation-player {
   color: var(--color-white);
   background-color: var(--color-purple50);
 }
+
+.annotation-range-div {
+  -webkit-appearance: none;
+  border-radius: 3px;
+  height: 3px;
+  margin-top: 0px;
+  margin-bottom: 2px;
+  position: relative;
+}
+
+.annotation-range-div:focus {
+  outline: none;
+}
+.annotation-range-div:hover {
+  height: 5px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.annotation-range-loaded {
+  -webkit-appearance: none;
+  background-color: var(--color-gray--dark);
+  border-radius: 3px;
+  height: 100%;
+  position: absolute;
+  width: 0px;
+}
+.annotation-range-loaded:focus {
+  outline: none;
+}
+
+
+.annotation-range-ondemand {
+  -webkit-appearance: none;
+  background-color: var(--color-white--25);
+  border-radius: 3px;
+  height: 100%;
+  position: absolute;
+  width: 0px;
+}
+.annotation-range-ondemand:focus {
+  outline: none;
+}

--- a/ui/src/css/components/tooltip.css
+++ b/ui/src/css/components/tooltip.css
@@ -18,7 +18,7 @@
 }
 
 .tooltip-seek-preview {
-  background-color: var(--color-charcoal--medium);
+  background-color: var(--color-charcoal--medium-dark);
   border-radius: 3px;
   color: var(--color-gray--dark);
   font-size: 12px;

--- a/ui/src/css/components/tooltip.css
+++ b/ui/src/css/components/tooltip.css
@@ -26,7 +26,6 @@
   padding: var(--spacing-2);
   pointer-events: none;
   position: absolute;
-  top: calc(100% + 16px);
   width: auto;
   max-width: 400px;
   z-index: 1;

--- a/ui/src/css/components/tooltip.css
+++ b/ui/src/css/components/tooltip.css
@@ -27,11 +27,10 @@
   pointer-events: none;
   position: absolute;
   width: auto;
-  max-width: 400px;
   z-index: 1;
 }
 .tooltip-seek-preview img {
-  max-width: 200px;
+
 }
 
 [tooltip] {

--- a/ui/src/css/components/tooltip.css
+++ b/ui/src/css/components/tooltip.css
@@ -30,7 +30,6 @@
   z-index: 3;
 }
 .tooltip-seek-preview img {
-
 }
 
 [tooltip] {

--- a/ui/src/css/components/tooltip.css
+++ b/ui/src/css/components/tooltip.css
@@ -27,7 +27,7 @@
   pointer-events: none;
   position: absolute;
   width: auto;
-  z-index: 1;
+  z-index: 3;
 }
 .tooltip-seek-preview img {
 

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -581,7 +581,7 @@ export class AnnotationMulti extends TatorElement {
     });
 
     this._slider.addEventListener("hidePreview", () => {
-      this._preview.cancelled=true;
+      this._preview.cancelled = true;
       this._preview.hide();
     });
 
@@ -917,8 +917,8 @@ export class AnnotationMulti extends TatorElement {
    */
   async handleFramePreview(evt) {
     let proposed_value = evt.detail.frame;
-     this._preview.cancelled = false;
-     if (proposed_value > 0) {
+    this._preview.cancelled = false;
+    if (proposed_value > 0) {
       // Get frame preview image
       const existing = this._preview.info;
       let video = null;
@@ -929,8 +929,7 @@ export class AnnotationMulti extends TatorElement {
         video = this._videoDivs[focus].children[0];
         useImage = true;
         bias += this._preview.img_height;
-       }
-
+      }
 
       // If we are already on this frame save some resources and just show the preview as-is
       if (existing.frame != proposed_value) {
@@ -938,11 +937,11 @@ export class AnnotationMulti extends TatorElement {
           let timeStr =
             this._timeStore.getAbsoluteTimeFromFrame(proposed_value);
           timeStr = timeStr.split("T")[1].split(".")[0];
-  
+
           this._preview.info = {
             frame: proposed_value,
             x: evt.detail.clientX,
-            y: evt.detail.clientY-(bias), // Add 15 due to page layout
+            y: evt.detail.clientY - bias, // Add 15 due to page layout
             time: timeStr,
             image: useImage,
           };
@@ -950,15 +949,16 @@ export class AnnotationMulti extends TatorElement {
           this._preview.info = {
             frame: proposed_value,
             x: evt.detail.clientX,
-            y: evt.detail.clientY-(bias), // Add 15 due to page layout
+            y: evt.detail.clientY - bias, // Add 15 due to page layout
             time: frameToTime(proposed_value, this._fps[this._longest_idx]),
             image: useImage,
           };
         }
 
-        if (useImage)
-        {
-          console.info(`Getting Frame Preview for ${proposed_value} existing = ${existing.frame}`);
+        if (useImage) {
+          console.info(
+            `Getting Frame Preview for ${proposed_value} existing = ${existing.frame}`
+          );
           let frame = await video.getScrubFrame(proposed_value);
           console.info(`Got it!`);
           if (this._preview.cancelled) {
@@ -970,8 +970,7 @@ export class AnnotationMulti extends TatorElement {
           frame.close();
 
           // Get annotations for frame
-          if (video._framedData.has(proposed_value))
-          {
+          if (video._framedData.has(proposed_value)) {
             this._preview.annotations = video._framedData.get(proposed_value);
           }
         }

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -928,7 +928,7 @@ export class AnnotationMulti extends TatorElement {
         let focus = this._focusIds[0];
         video = this._videoDivs[focus].children[0];
         useImage = true;
-        bias += 240;
+        bias += this._preview.img_height;
        }
 
 

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -1059,6 +1059,12 @@ export class AnnotationPlayer extends TatorElement {
         let frame = await this._video.getScrubFrame(proposed_value);
         this._preview.image = frame;
         frame.close();
+
+        // Get annotations for frame
+        if (this._video._framedData.has(proposed_value))
+        {
+          this._preview.annotations = this._video._framedData.get(proposed_value);
+        }
       }
 
 

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -1063,10 +1063,11 @@ export class AnnotationPlayer extends TatorElement {
             this._timeStore.getAbsoluteTimeFromFrame(proposed_value);
           timeStr = timeStr.split("T")[1].split(".")[0];
   
+          let bias = 15;
           this._preview.info = {
             frame: proposed_value,
             x: evt.detail.clientX,
-            y: evt.detail.clientY+15, // Add 15 due to page layout
+            y: evt.detail.clientY-(240+50), 
             time: timeStr,
             image: true,
           };
@@ -1074,7 +1075,7 @@ export class AnnotationPlayer extends TatorElement {
           this._preview.info = {
             frame: proposed_value,
             x: evt.detail.clientX,
-            y: evt.detail.clientY+15, // Add 15 due to page layout
+            y: evt.detail.clientY-(240+50),
             time: frameToTime(proposed_value, this._fps),
             image: true,
           };

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -1050,9 +1050,9 @@ export class AnnotationPlayer extends TatorElement {
    * Callback used when a user hovers over the seek bar
    */
   async handleFramePreview(evt) {
-     let proposed_value = evt.detail.frame;
-     this._preview.cancelled = false;
-     if (proposed_value > 0) {
+    let proposed_value = evt.detail.frame;
+    this._preview.cancelled = false;
+    if (proposed_value > 0) {
       // Get frame preview image
       const existing = this._preview.info;
 
@@ -1062,12 +1062,12 @@ export class AnnotationPlayer extends TatorElement {
           let timeStr =
             this._timeStore.getAbsoluteTimeFromFrame(proposed_value);
           timeStr = timeStr.split("T")[1].split(".")[0];
-  
+
           let bias = 15;
           this._preview.info = {
             frame: proposed_value,
             x: evt.detail.clientX,
-            y: evt.detail.clientY-(this._preview.img_height+50), 
+            y: evt.detail.clientY - (this._preview.img_height + 50),
             time: timeStr,
             image: true,
           };
@@ -1075,13 +1075,15 @@ export class AnnotationPlayer extends TatorElement {
           this._preview.info = {
             frame: proposed_value,
             x: evt.detail.clientX,
-            y: evt.detail.clientY-(this._preview.img_height+50),
+            y: evt.detail.clientY - (this._preview.img_height + 50),
             time: frameToTime(proposed_value, this._fps),
             image: true,
           };
         }
 
-        console.info(`Getting Frame Preview for ${proposed_value} existing = ${existing.frame}`);
+        console.info(
+          `Getting Frame Preview for ${proposed_value} existing = ${existing.frame}`
+        );
         let frame = await this._video.getScrubFrame(proposed_value);
         console.info(`Got it!`);
         if (this._preview.cancelled) {
@@ -1093,9 +1095,9 @@ export class AnnotationPlayer extends TatorElement {
         frame.close();
 
         // Get annotations for frame
-        if (this._video._framedData.has(proposed_value))
-        {
-          this._preview.annotations = this._video._framedData.get(proposed_value);
+        if (this._video._framedData.has(proposed_value)) {
+          this._preview.annotations =
+            this._video._framedData.get(proposed_value);
         }
       }
       this._preview.show();

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -1211,6 +1211,7 @@ export class AnnotationPlayer extends TatorElement {
     // Max value on slider is 1 less the frame count.
     this._slider.setAttribute("max", Number(val.num_frames) - 1);
     this._slider.fps = val.fps;
+    this._preview.mediaInfo = val;
     this._fps = val.fps;
     this._totalTime.textContent =
       "/ " + frameToTime(val.num_frames, this._mediaInfo.fps);

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -1052,7 +1052,15 @@ export class AnnotationPlayer extends TatorElement {
      let proposed_value = evt.detail.frame;
      if (proposed_value > 0) {
       // Get frame preview image
-      let frame = await this._video.getScrubFrame(proposed_value);
+      const existing = this._preview.info;
+
+      // If we are already on this frame save some resources and just show the preview as-is
+      if (existing.frame != proposed_value) {
+        let frame = await this._video.getScrubFrame(proposed_value);
+        this._preview.image = frame;
+        frame.close();
+      }
+
 
       if (this._timeMode == "utc") {
         let timeStr =
@@ -1064,7 +1072,7 @@ export class AnnotationPlayer extends TatorElement {
           x: evt.detail.clientX,
           y: evt.detail.clientY+15, // Add 15 due to page layout
           time: timeStr,
-          image: frame,
+          image: true,
         };
       } else {
         this._preview.info = {
@@ -1072,10 +1080,9 @@ export class AnnotationPlayer extends TatorElement {
           x: evt.detail.clientX,
           y: evt.detail.clientY+15, // Add 15 due to page layout
           time: frameToTime(proposed_value, this._fps),
-          image: frame,
+          image: true,
         };
       }
-      frame.close();
     } else {
       this._preview.hide();
     }

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -1048,9 +1048,12 @@ export class AnnotationPlayer extends TatorElement {
   /**
    * Callback used when a user hovers over the seek bar
    */
-  handleFramePreview(evt) {
+  async handleFramePreview(evt) {
      let proposed_value = evt.detail.frame;
      if (proposed_value > 0) {
+      // Get frame preview image
+      let frame = await this._video.getScrubFrame(proposed_value);
+
       if (this._timeMode == "utc") {
         let timeStr =
           this._timeStore.getAbsoluteTimeFromFrame(proposed_value);
@@ -1061,6 +1064,7 @@ export class AnnotationPlayer extends TatorElement {
           x: evt.detail.clientX,
           y: evt.detail.clientY+15, // Add 15 due to page layout
           time: timeStr,
+          image: frame,
         };
       } else {
         this._preview.info = {
@@ -1068,8 +1072,10 @@ export class AnnotationPlayer extends TatorElement {
           x: evt.detail.clientX,
           y: evt.detail.clientY+15, // Add 15 due to page layout
           time: frameToTime(proposed_value, this._fps),
+          image: frame,
         };
       }
+      frame.close();
     } else {
       this._preview.hide();
     }

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -456,6 +456,8 @@ export class AnnotationPlayer extends TatorElement {
     this._slider = document.createElement("seek-bar");
     seekDiv.appendChild(this._slider);
     outerDiv.appendChild(seekDiv);
+    this._preview = document.createElement("media-seek-preview");
+    this._slider._shadow.appendChild(this._preview);
 
     var innerDiv = document.createElement("div");
     this._videoTimeline = document.createElement("video-timeline");
@@ -652,6 +654,14 @@ export class AnnotationPlayer extends TatorElement {
 
     this._slider.addEventListener("change", (evt) => {
       this.handleSliderChange(evt);
+    });
+
+    this._slider.addEventListener("framePreview", (evt) => {
+      this.handleFramePreview(evt);
+    });
+
+    this._slider.addEventListener("hidePreview", () => {
+      this._preview.hide();
     });
 
     play.addEventListener("click", () => {
@@ -1036,6 +1046,35 @@ export class AnnotationPlayer extends TatorElement {
   }
 
   /**
+   * Callback used when a user hovers over the seek bar
+   */
+  handleFramePreview(evt) {
+     let proposed_value = evt.detail.frame;
+     if (proposed_value > 0) {
+      if (this._timeMode == "utc") {
+        let timeStr =
+          this._timeStore.getAbsoluteTimeFromFrame(proposed_value);
+        timeStr = timeStr.split("T")[1].split(".")[0];
+
+        this._preview.info = {
+          frame: proposed_value,
+          x: evt.detail.clientX,
+          y: evt.detail.clientY+15, // Add 15 due to page layout
+          time: timeStr,
+        };
+      } else {
+        this._preview.info = {
+          frame: proposed_value,
+          x: evt.detail.clientX,
+          y: evt.detail.clientY+15, // Add 15 due to page layout
+          time: frameToTime(proposed_value, this._fps),
+        };
+      }
+    } else {
+      this._preview.hide();
+    }
+  }
+  /**
    * Callback used when user clicks one of the seek bars
    */
   handleSliderChange(evt) {
@@ -1362,9 +1401,9 @@ export class AnnotationPlayer extends TatorElement {
     this._entityTimeline.setDisplayMode(this._displayMode);
 
     if (this._displayMode == "utc") {
-      this._slider.useUtcTime(this._timeStore);
+      this._timeMode = "utc";
     } else {
-      this._slider.useRelativeTime();
+      this._timeMode = "relative";
     }
 
     this.dispatchEvent(

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -1067,7 +1067,7 @@ export class AnnotationPlayer extends TatorElement {
           this._preview.info = {
             frame: proposed_value,
             x: evt.detail.clientX,
-            y: evt.detail.clientY-(240+50), 
+            y: evt.detail.clientY-(this._preview.img_height+50), 
             time: timeStr,
             image: true,
           };
@@ -1075,7 +1075,7 @@ export class AnnotationPlayer extends TatorElement {
           this._preview.info = {
             frame: proposed_value,
             x: evt.detail.clientX,
-            y: evt.detail.clientY-(240+50),
+            y: evt.detail.clientY-(this._preview.img_height+50),
             time: frameToTime(proposed_value, this._fps),
             image: true,
           };

--- a/ui/src/js/annotation/media-seek-preview.js
+++ b/ui/src/js/annotation/media-seek-preview.js
@@ -141,12 +141,19 @@ export class MediaSeekPreview extends TatorElement {
       {
         this._img.style.display = "none";
       }
-      this.show();
     }
   }
 
   get info() {
     return this._info;
+  }
+
+  set cancelled(val) {
+    this._cancelled = val;
+  }
+
+  get cancelled() {
+    return this._cancelled;
   }
 }
 

--- a/ui/src/js/annotation/media-seek-preview.js
+++ b/ui/src/js/annotation/media-seek-preview.js
@@ -26,14 +26,18 @@ export class MediaSeekPreview extends TatorElement {
     nameDiv.appendChild(this._time);
     nameDiv.appendChild(this._frame);
 
-    // Image is aspirational
+    // Set an image size here that works for both 144 or 360
     this._img = document.createElement('canvas');
-    this._img.width = 300;
+    this._img.width = 240;
     this._img.height = 240;
     this._ctx = this._img.getContext('2d');
     this._previewBox.appendChild(this._img);
 
     this._info = {};
+  }
+
+  get img_height() {
+    return this._img.height;
   }
 
   show() {

--- a/ui/src/js/annotation/media-seek-preview.js
+++ b/ui/src/js/annotation/media-seek-preview.js
@@ -32,11 +32,11 @@ export class MediaSeekPreview extends TatorElement {
   }
 
   show() {
-    this._previewBox.hidden = false;
+    this._previewBox.style.display = "block";
   }
 
   hide() {
-    this._previewBox.hidden = true;
+    this._previewBox.style.display = "none";
   }
 
   set info(val) {
@@ -46,8 +46,8 @@ export class MediaSeekPreview extends TatorElement {
     if (val !== null && val !== -1) {
       this._frame.textContent = `  (${val.frame})`;
       this._time.textContent = val.time;
-      const pos = val.margin - this._previewBox.clientWidth / 2;
-      this._previewBox.style.marginLeft = `${pos}px`;
+      this._previewBox.style.left = `${val.x}px`;
+      this._previewBox.style.top = `${val.y}px`;
       this.show();
     }
   }

--- a/ui/src/js/annotation/media-seek-preview.js
+++ b/ui/src/js/annotation/media-seek-preview.js
@@ -62,6 +62,16 @@ export class MediaSeekPreview extends TatorElement {
       this._time.textContent = val.time;
       this._previewBox.style.left = `${val.x}px`;
       this._previewBox.style.top = `${val.y}px`;
+
+      // If a preview image was supplied, display else hide the canvas
+      if (val.image) {
+        this._ctx.drawImage(val.image, 0,0, this._img.width, this._img.height);
+        this._img.style.display = "block";
+      }
+      else
+      {
+        this._img.style.display = "none";
+      }
       this.show();
     }
   }

--- a/ui/src/js/annotation/media-seek-preview.js
+++ b/ui/src/js/annotation/media-seek-preview.js
@@ -27,10 +27,11 @@ export class MediaSeekPreview extends TatorElement {
     nameDiv.appendChild(this._frame);
 
     // Image is aspirational
-    //this._img = document.createElement('img');
-    //this._img.setAttribute("style", "max-width: 100%;");
-    //this._img.setAttribute("crossorigin", "anonymous");
-    //this._previewBox.appendChild(this._img);
+    this._img = document.createElement('canvas');
+    this._img.width = 360;
+    this._img.height = 360;
+    this._ctx = this._img.getContext('2d');
+    this._previewBox.appendChild(this._img);
   }
 
   show() {
@@ -39,6 +40,17 @@ export class MediaSeekPreview extends TatorElement {
 
   hide() {
     this._previewBox.style.display = "none";
+  }
+
+  set mediaInfo(val) {
+    // Calculate the aspect ratio and update the canvas size accordingly
+    const aspectRatio = val.width / val.height;
+    this._img.width = 360;
+    this._img.height = 360 / aspectRatio;
+
+    // Fill it black on initialization
+    this._ctx.fillStyle = 'black';
+    this._ctx.fillRect(0, 0, this._img.width, this._img.height);
   }
 
   set info(val) {

--- a/ui/src/js/annotation/media-seek-preview.js
+++ b/ui/src/js/annotation/media-seek-preview.js
@@ -60,6 +60,65 @@ export class MediaSeekPreview extends TatorElement {
     this._ctx.drawImage(val, 0,0, this._img.width, this._img.height);
     this._img.style.display = "block";
   }
+
+  set annotations(val)
+  {
+    // Dictionary by type
+    for (const typeId of val.keys())
+    {
+      for (const localization of val.get(typeId))
+      {
+        if (localization.type.indexOf("box") >= 0)
+        {
+          this._ctx.strokeStyle = "rgb(64,224,208)";
+          this._ctx.lineWidth = 3;
+          this._ctx.strokeRect(localization.x * this._img.width, localization.y * this._img.height, localization.width * this._img.width, localization.height * this._img.height);
+        
+          // Fill with a 50% alpha color
+          this._ctx.fillStyle = "rgb(64,224,208)";
+          this._ctx.globalAlpha = 0.5;
+          this._ctx.fillRect(localization.x * this._img.width, localization.y * this._img.height, localization.width * this._img.width, localization.height * this._img.height);
+        }
+        else if (localization.type.indexOf("dot") >= 0)
+        {
+          this._ctx.fillStyle = "rgb(64,224,208)";
+          this._ctx.beginPath();
+          this._ctx.arc(localization.x * this._img.width, localization.y * this._img.height, 5, 0, 2 * Math.PI);
+          this._ctx.fill();
+        }
+        else if (localization.type.indexOf("line") >= 0)
+        {
+          this._ctx.strokeStyle = "rgb(64,224,208)";
+          this._ctx.lineWidth = 3;
+          this._ctx.beginPath();
+          this._ctx.moveTo(localization.x * this._img.width, localization.y * this._img.height);
+          this._ctx.lineTo((localization.x + localization.u) * this._img.width, (localization.y + localization.v) * this._img.height);
+          this._ctx.stroke();
+        }
+        else if (localization.type.indexOf("poly") >= 0)
+        {
+          this._ctx.strokeStyle = "rgb(64,224,208)";
+          this._ctx.lineWidth = 3;
+          this._ctx.beginPath();
+          this._ctx.moveTo(localization.points[0][0] * this._img.width, localization.points[0][1] * this._img.height);
+          for (let idx = 1; idx < localization.points.length; idx++)
+          {
+            this._ctx.lineTo(localization.points[idx][0] * this._img.width, localization.points[idx][1] * this._img.height);
+          }
+          this._ctx.closePath();
+          this._ctx.stroke();
+
+          // Fill with a 50% alpha color
+          this._ctx.fillStyle = "rgb(64,224,208)";
+          this._ctx.globalAlpha = 0.5;
+          this._ctx.fill();
+        }
+
+        // Reset alpha
+        this._ctx.globalAlpha = 1;
+      }
+    }
+  }
   set info(val) {
     if (this._info.frame === val.frame) {
       this._previewBox.style.left = `${val.x}px`;

--- a/ui/src/js/annotation/media-seek-preview.js
+++ b/ui/src/js/annotation/media-seek-preview.js
@@ -27,10 +27,10 @@ export class MediaSeekPreview extends TatorElement {
     nameDiv.appendChild(this._frame);
 
     // Set an image size here that works for both 144 or 360
-    this._img = document.createElement('canvas');
+    this._img = document.createElement("canvas");
     this._img.width = 240;
     this._img.height = 240;
-    this._ctx = this._img.getContext('2d');
+    this._ctx = this._img.getContext("2d");
     this._previewBox.appendChild(this._img);
 
     this._info = {};
@@ -52,64 +52,79 @@ export class MediaSeekPreview extends TatorElement {
     // Calculate the aspect ratio and update the canvas size accordingly
     const aspectRatio = val.width / val.height;
     let newWidth = this._img.height * aspectRatio;
-    if (this._img.width != newWidth)
-    {
+    if (this._img.width != newWidth) {
       this._img.width = newWidth;
       // Fill it black on initialization
-      this._ctx.fillStyle = 'black';
+      this._ctx.fillStyle = "black";
       this._ctx.fillRect(0, 0, this._img.width, this._img.height);
     }
   }
 
-  set image(val)
-  {
-    this._ctx.drawImage(val, 0,0, this._img.width, this._img.height);
+  set image(val) {
+    this._ctx.drawImage(val, 0, 0, this._img.width, this._img.height);
     this._img.style.display = "block";
   }
 
-  set annotations(val)
-  {
+  set annotations(val) {
     // Dictionary by type
-    for (const typeId of val.keys())
-    {
-      for (const localization of val.get(typeId))
-      {
-        if (localization.type.indexOf("box") >= 0)
-        {
+    for (const typeId of val.keys()) {
+      for (const localization of val.get(typeId)) {
+        if (localization.type.indexOf("box") >= 0) {
           this._ctx.strokeStyle = "rgb(64,224,208)";
           this._ctx.lineWidth = 3;
-          this._ctx.strokeRect(localization.x * this._img.width, localization.y * this._img.height, localization.width * this._img.width, localization.height * this._img.height);
-        
+          this._ctx.strokeRect(
+            localization.x * this._img.width,
+            localization.y * this._img.height,
+            localization.width * this._img.width,
+            localization.height * this._img.height
+          );
+
           // Fill with a 50% alpha color
           this._ctx.fillStyle = "rgb(64,224,208)";
           this._ctx.globalAlpha = 0.5;
-          this._ctx.fillRect(localization.x * this._img.width, localization.y * this._img.height, localization.width * this._img.width, localization.height * this._img.height);
-        }
-        else if (localization.type.indexOf("dot") >= 0)
-        {
+          this._ctx.fillRect(
+            localization.x * this._img.width,
+            localization.y * this._img.height,
+            localization.width * this._img.width,
+            localization.height * this._img.height
+          );
+        } else if (localization.type.indexOf("dot") >= 0) {
           this._ctx.fillStyle = "rgb(64,224,208)";
           this._ctx.beginPath();
-          this._ctx.arc(localization.x * this._img.width, localization.y * this._img.height, 5, 0, 2 * Math.PI);
+          this._ctx.arc(
+            localization.x * this._img.width,
+            localization.y * this._img.height,
+            5,
+            0,
+            2 * Math.PI
+          );
           this._ctx.fill();
-        }
-        else if (localization.type.indexOf("line") >= 0)
-        {
+        } else if (localization.type.indexOf("line") >= 0) {
           this._ctx.strokeStyle = "rgb(64,224,208)";
           this._ctx.lineWidth = 3;
           this._ctx.beginPath();
-          this._ctx.moveTo(localization.x * this._img.width, localization.y * this._img.height);
-          this._ctx.lineTo((localization.x + localization.u) * this._img.width, (localization.y + localization.v) * this._img.height);
+          this._ctx.moveTo(
+            localization.x * this._img.width,
+            localization.y * this._img.height
+          );
+          this._ctx.lineTo(
+            (localization.x + localization.u) * this._img.width,
+            (localization.y + localization.v) * this._img.height
+          );
           this._ctx.stroke();
-        }
-        else if (localization.type.indexOf("poly") >= 0)
-        {
+        } else if (localization.type.indexOf("poly") >= 0) {
           this._ctx.strokeStyle = "rgb(64,224,208)";
           this._ctx.lineWidth = 3;
           this._ctx.beginPath();
-          this._ctx.moveTo(localization.points[0][0] * this._img.width, localization.points[0][1] * this._img.height);
-          for (let idx = 1; idx < localization.points.length; idx++)
-          {
-            this._ctx.lineTo(localization.points[idx][0] * this._img.width, localization.points[idx][1] * this._img.height);
+          this._ctx.moveTo(
+            localization.points[0][0] * this._img.width,
+            localization.points[0][1] * this._img.height
+          );
+          for (let idx = 1; idx < localization.points.length; idx++) {
+            this._ctx.lineTo(
+              localization.points[idx][0] * this._img.width,
+              localization.points[idx][1] * this._img.height
+            );
           }
           this._ctx.closePath();
           this._ctx.stroke();
@@ -142,9 +157,7 @@ export class MediaSeekPreview extends TatorElement {
       // If a preview image was supplied, display else hide the canvas
       if (val.image) {
         this._img.style.display = "block";
-      }
-      else
-      {
+      } else {
         this._img.style.display = "none";
       }
     }

--- a/ui/src/js/annotation/media-seek-preview.js
+++ b/ui/src/js/annotation/media-seek-preview.js
@@ -11,6 +11,8 @@ export class MediaSeekPreview extends TatorElement {
     this._shadow.appendChild(this._previewBox);
 
     const nameDiv = document.createElement("div");
+    nameDiv.style.display = "flex";
+    nameDiv.style.justifyContent = "center";
     this._previewBox.appendChild(nameDiv);
 
     //  const nameLabel = document.createElement('span');

--- a/ui/src/js/annotation/media-seek-preview.js
+++ b/ui/src/js/annotation/media-seek-preview.js
@@ -28,8 +28,8 @@ export class MediaSeekPreview extends TatorElement {
 
     // Image is aspirational
     this._img = document.createElement('canvas');
-    this._img.width = 360;
-    this._img.height = 360;
+    this._img.width = 300;
+    this._img.height = 300;
     this._ctx = this._img.getContext('2d');
     this._previewBox.appendChild(this._img);
   }
@@ -45,8 +45,8 @@ export class MediaSeekPreview extends TatorElement {
   set mediaInfo(val) {
     // Calculate the aspect ratio and update the canvas size accordingly
     const aspectRatio = val.width / val.height;
-    this._img.width = 360;
-    this._img.height = 360 / aspectRatio;
+    this._img.width = 300;
+    this._img.height = 300 / aspectRatio;
 
     // Fill it black on initialization
     this._ctx.fillStyle = 'black';

--- a/ui/src/js/annotation/media-seek-preview.js
+++ b/ui/src/js/annotation/media-seek-preview.js
@@ -70,6 +70,7 @@ export class MediaSeekPreview extends TatorElement {
     for (const typeId of val.keys()) {
       for (const localization of val.get(typeId)) {
         if (localization.type.indexOf("box") >= 0) {
+          this._ctx.globalAlpha = 0.7;
           this._ctx.strokeStyle = "rgb(64,224,208)";
           this._ctx.lineWidth = 3;
           this._ctx.strokeRect(
@@ -81,7 +82,7 @@ export class MediaSeekPreview extends TatorElement {
 
           // Fill with a 50% alpha color
           this._ctx.fillStyle = "rgb(64,224,208)";
-          this._ctx.globalAlpha = 0.5;
+          this._ctx.globalAlpha = 0.2;
           this._ctx.fillRect(
             localization.x * this._img.width,
             localization.y * this._img.height,
@@ -89,6 +90,7 @@ export class MediaSeekPreview extends TatorElement {
             localization.height * this._img.height
           );
         } else if (localization.type.indexOf("dot") >= 0) {
+          this._ctx.globalAlpha = 0.7;
           this._ctx.fillStyle = "rgb(64,224,208)";
           this._ctx.beginPath();
           this._ctx.arc(
@@ -100,6 +102,7 @@ export class MediaSeekPreview extends TatorElement {
           );
           this._ctx.fill();
         } else if (localization.type.indexOf("line") >= 0) {
+          this._ctx.globalAlpha = 0.7;
           this._ctx.strokeStyle = "rgb(64,224,208)";
           this._ctx.lineWidth = 3;
           this._ctx.beginPath();
@@ -113,6 +116,7 @@ export class MediaSeekPreview extends TatorElement {
           );
           this._ctx.stroke();
         } else if (localization.type.indexOf("poly") >= 0) {
+          this._ctx.globalAlpha = 0.7;
           this._ctx.strokeStyle = "rgb(64,224,208)";
           this._ctx.lineWidth = 3;
           this._ctx.beginPath();
@@ -131,7 +135,7 @@ export class MediaSeekPreview extends TatorElement {
 
           // Fill with a 50% alpha color
           this._ctx.fillStyle = "rgb(64,224,208)";
-          this._ctx.globalAlpha = 0.5;
+          this._ctx.globalAlpha = 0.2;
           this._ctx.fill();
         }
 

--- a/ui/src/js/annotation/media-seek-preview.js
+++ b/ui/src/js/annotation/media-seek-preview.js
@@ -29,7 +29,7 @@ export class MediaSeekPreview extends TatorElement {
     // Image is aspirational
     this._img = document.createElement('canvas');
     this._img.width = 300;
-    this._img.height = 300;
+    this._img.height = 240;
     this._ctx = this._img.getContext('2d');
     this._previewBox.appendChild(this._img);
 
@@ -47,12 +47,14 @@ export class MediaSeekPreview extends TatorElement {
   set mediaInfo(val) {
     // Calculate the aspect ratio and update the canvas size accordingly
     const aspectRatio = val.width / val.height;
-    this._img.width = 300;
-    this._img.height = 300 / aspectRatio;
-
-    // Fill it black on initialization
-    this._ctx.fillStyle = 'black';
-    this._ctx.fillRect(0, 0, this._img.width, this._img.height);
+    let newWidth = this._img.height * aspectRatio;
+    if (this._img.width != newWidth)
+    {
+      this._img.width = newWidth;
+      // Fill it black on initialization
+      this._ctx.fillStyle = 'black';
+      this._ctx.fillRect(0, 0, this._img.width, this._img.height);
+    }
   }
 
   set image(val)

--- a/ui/src/js/annotation/media-seek-preview.js
+++ b/ui/src/js/annotation/media-seek-preview.js
@@ -32,6 +32,8 @@ export class MediaSeekPreview extends TatorElement {
     this._img.height = 300;
     this._ctx = this._img.getContext('2d');
     this._previewBox.appendChild(this._img);
+
+    this._info = {};
   }
 
   show() {
@@ -53,8 +55,17 @@ export class MediaSeekPreview extends TatorElement {
     this._ctx.fillRect(0, 0, this._img.width, this._img.height);
   }
 
+  set image(val)
+  {
+    this._ctx.drawImage(val, 0,0, this._img.width, this._img.height);
+    this._img.style.display = "block";
+  }
   set info(val) {
-    if (this._info == val && val !== null && val !== -1) this.show();
+    if (this._info.frame === val.frame) {
+      this._previewBox.style.left = `${val.x}px`;
+      this._previewBox.style.top = `${val.y}px`;
+      this.show();
+    }
 
     this._info = val;
     if (val !== null && val !== -1) {
@@ -65,7 +76,6 @@ export class MediaSeekPreview extends TatorElement {
 
       // If a preview image was supplied, display else hide the canvas
       if (val.image) {
-        this._ctx.drawImage(val.image, 0,0, this._img.width, this._img.height);
         this._img.style.display = "block";
       }
       else
@@ -74,6 +84,10 @@ export class MediaSeekPreview extends TatorElement {
       }
       this.show();
     }
+  }
+
+  get info() {
+    return this._info;
   }
 }
 

--- a/ui/src/js/annotation/seek-bar.js
+++ b/ui/src/js/annotation/seek-bar.js
@@ -264,7 +264,7 @@ export class SeekBar extends TatorElement {
     const start = range[0];
     const end = range[1];
     const startPercentage = start / this._max;
-    const endPercentage = end / this._max;
+    const endPercentage = Math.min(1,end / this._max);
     this.onDemandProgress.style.marginLeft = `${startPercentage * 100}%`;
     const widthPx = Math.round(
       (endPercentage - startPercentage) * this.bar.clientWidth

--- a/ui/src/js/annotation/seek-bar.js
+++ b/ui/src/js/annotation/seek-bar.js
@@ -47,6 +47,7 @@ export class SeekBar extends TatorElement {
     this.bar.addEventListener("click", clickHandler);
 
     var mouseOver = (evt) => {
+      this.bar.classList.add("annotation-range-div-active");
       var width = that.offsetWidth;
       var startX = that.offsetLeft;
       if (width == 0) {
@@ -88,6 +89,10 @@ export class SeekBar extends TatorElement {
     this.bar.addEventListener("mousemove", mouseOver);
     this.bar.addEventListener("mouseout", () => {
       this.preview.hide();
+      if (this._active == false)
+      {
+        this.bar.classList.remove("annotation-range-div-active");
+      }
     });
 
     var dragHandler = function (evt) {
@@ -114,6 +119,7 @@ export class SeekBar extends TatorElement {
     var releaseMouse = (evt) => {
       this.bar.addEventListener("mousemove", mouseOver);
       that.bar.removeAttribute("wide-tooltip");
+      this.bar.classList.remove("annotation-range-div-active");
       console.info("RELEASE MOUSE.");
       this._active = false;
       clearInterval(that._periodicCheck);
@@ -131,6 +137,7 @@ export class SeekBar extends TatorElement {
         return;
       }
       this.preview.hide();
+      this.bar.classList.add("annotation-range-div-active");
       this.bar.removeEventListener("mousemove", mouseOver);
       this._active = true;
       this._lastValue = this.value;

--- a/ui/src/js/annotation/seek-bar.js
+++ b/ui/src/js/annotation/seek-bar.js
@@ -5,7 +5,7 @@ export class SeekBar extends TatorElement {
   constructor() {
     super();
     this.bar = document.createElement("div");
-    this.bar.setAttribute("class", "range-div select-pointer");
+    this.bar.setAttribute("class", "annotation-range-div select-pointer");
     this._shadow.appendChild(this.bar);
 
     this.handle = document.createElement("div");
@@ -161,9 +161,9 @@ export class SeekBar extends TatorElement {
     });
 
     this.loadProgress = document.createElement("div");
-    this.loadProgress.setAttribute("class", "range-loaded");
+    this.loadProgress.setAttribute("class", "annotation-range-loaded");
     this.onDemandProgress = document.createElement("div");
-    this.onDemandProgress.setAttribute("class", "range-ondemand");
+    this.onDemandProgress.setAttribute("class", "annotation-range-ondemand");
     this.bar.appendChild(this.loadProgress);
     this.bar.appendChild(this.onDemandProgress);
 

--- a/ui/src/js/annotation/seek-bar.js
+++ b/ui/src/js/annotation/seek-bar.js
@@ -38,7 +38,7 @@ export class SeekBar extends TatorElement {
       that.dispatchEvent(
         new CustomEvent("change", {
           composed: true,
-          detail: { frame: that.value},
+          detail: { frame: that.value },
         })
       );
       evt.stopPropagation();
@@ -59,21 +59,24 @@ export class SeekBar extends TatorElement {
         percentage * (that._max - that._min) + that._min
       );
 
-      this.dispatchEvent(new CustomEvent("framePreview", {composed:true, detail: 
-        {
-          frame:proposed_value,
-          clientX: evt.clientX,
-          clientY: evt.clientY,
-        }}));
+      this.dispatchEvent(
+        new CustomEvent("framePreview", {
+          composed: true,
+          detail: {
+            frame: proposed_value,
+            clientX: evt.clientX,
+            clientY: evt.clientY,
+          },
+        })
+      );
       evt.stopPropagation();
       return false;
     };
 
     this.bar.addEventListener("mousemove", mouseOver);
     this.bar.addEventListener("mouseout", () => {
-      this.dispatchEvent(new CustomEvent("hidePreview", {composed:true}));
-      if (this._active == false)
-      {
+      this.dispatchEvent(new CustomEvent("hidePreview", { composed: true }));
+      if (this._active == false) {
         this.bar.classList.remove("annotation-range-div-active");
       }
     });
@@ -119,7 +122,7 @@ export class SeekBar extends TatorElement {
       if (this._disabled == true) {
         return;
       }
-      this.dispatchEvent(new CustomEvent("hidePreview", {composed:true}));
+      this.dispatchEvent(new CustomEvent("hidePreview", { composed: true }));
       this.bar.classList.add("annotation-range-div-active");
       this.bar.removeEventListener("mousemove", mouseOver);
       this._active = true;
@@ -245,7 +248,7 @@ export class SeekBar extends TatorElement {
     const start = range[0];
     const end = range[1];
     const startPercentage = start / this._max;
-    const endPercentage = Math.min(1,end / this._max);
+    const endPercentage = Math.min(1, end / this._max);
     this.onDemandProgress.style.marginLeft = `${startPercentage * 100}%`;
     const widthPx = Math.round(
       (endPercentage - startPercentage) * this.bar.clientWidth

--- a/ui/src/js/annotation/seek-bar.js
+++ b/ui/src/js/annotation/seek-bar.js
@@ -9,7 +9,7 @@ export class SeekBar extends TatorElement {
     this._shadow.appendChild(this.bar);
 
     this.handle = document.createElement("div");
-    this.handle.setAttribute("class", "range-handle");
+    this.handle.setAttribute("class", "annotation-range-handle");
     this.handle.setAttribute("tabindex", "0");
     this.handle.style.cursor = "pointer";
     this.bar.appendChild(this.handle);
@@ -48,6 +48,7 @@ export class SeekBar extends TatorElement {
 
     var mouseOver = (evt) => {
       this.bar.classList.add("annotation-range-div-active");
+      this.handle.classList.add("annotation-range-handle-active");
       var width = that.offsetWidth;
       var startX = that.offsetLeft;
       if (width == 0) {
@@ -78,6 +79,7 @@ export class SeekBar extends TatorElement {
       this.dispatchEvent(new CustomEvent("hidePreview", { composed: true }));
       if (this._active == false) {
         this.bar.classList.remove("annotation-range-div-active");
+        this.handle.classList.remove("annotation-range-handle-active");
       }
     });
 
@@ -106,13 +108,14 @@ export class SeekBar extends TatorElement {
       this.bar.addEventListener("mousemove", mouseOver);
       that.bar.removeAttribute("wide-tooltip");
       this.bar.classList.remove("annotation-range-div-active");
+      this.handle.classList.remove("annotation-range-handle-active");
       console.info("RELEASE MOUSE.");
       this._active = false;
       clearInterval(that._periodicCheck);
       document.removeEventListener("mouseup", releaseMouse);
       document.removeEventListener("mousemove", dragHandler);
       that.dispatchEvent(new CustomEvent("change", { composed: true }));
-      that.handle.classList.remove("range-handle-selected");
+      that.handle.classList.remove("annotation-range-handle-selected");
       // Add back in event handler next iteration (time=0)
       setTimeout(() => {
         that.bar.addEventListener("click", clickHandler);
@@ -124,6 +127,7 @@ export class SeekBar extends TatorElement {
       }
       this.dispatchEvent(new CustomEvent("hidePreview", { composed: true }));
       this.bar.classList.add("annotation-range-div-active");
+      this.handle.classList.add("annotation-range-handle-active");
       this.bar.removeEventListener("mousemove", mouseOver);
       this._active = true;
       this._lastValue = this.value;
@@ -148,7 +152,7 @@ export class SeekBar extends TatorElement {
       that.bar.removeEventListener("click", clickHandler);
       document.addEventListener("mouseup", releaseMouse);
       document.addEventListener("mousemove", dragHandler);
-      this.handle.classList.add("range-handle-selected");
+      this.handle.classList.add("annotation-range-handle-selected");
       evt.stopPropagation();
       return false;
     });

--- a/ui/src/js/annotation/seek-bar.js
+++ b/ui/src/js/annotation/seek-bar.js
@@ -38,7 +38,7 @@ export class SeekBar extends TatorElement {
       that.dispatchEvent(
         new CustomEvent("change", {
           composed: true,
-          detail: { frame: that.value },
+          detail: { frame: that.value},
         })
       );
       evt.stopPropagation();
@@ -59,36 +59,19 @@ export class SeekBar extends TatorElement {
         percentage * (that._max - that._min) + that._min
       );
 
-      if (proposed_value > 0) {
-        if (this._timeMode == "utc") {
-          let timeStr =
-            this._timeStore.getAbsoluteTimeFromFrame(proposed_value);
-          timeStr = timeStr.split("T")[1].split(".")[0];
-
-          this.preview.info = {
-            frame: proposed_value,
-            margin: evt.clientX - startX,
-            time: timeStr,
-          };
-        } else {
-          this.preview.info = {
-            frame: proposed_value,
-            margin: evt.clientX - startX,
-            time: frameToTime(proposed_value, this._fps),
-          };
-        }
-      } else {
-        this.preview.hide();
-      }
-
+      this.dispatchEvent(new CustomEvent("framePreview", {composed:true, detail: 
+        {
+          frame:proposed_value,
+          clientX: evt.clientX,
+          clientY: evt.clientY,
+        }}));
       evt.stopPropagation();
       return false;
     };
-    this.preview = document.createElement("media-seek-preview");
-    this.bar.appendChild(this.preview);
+
     this.bar.addEventListener("mousemove", mouseOver);
     this.bar.addEventListener("mouseout", () => {
-      this.preview.hide();
+      this.dispatchEvent(new CustomEvent("hidePreview", {composed:true}));
       if (this._active == false)
       {
         this.bar.classList.remove("annotation-range-div-active");
@@ -136,7 +119,7 @@ export class SeekBar extends TatorElement {
       if (this._disabled == true) {
         return;
       }
-      this.preview.hide();
+      this.dispatchEvent(new CustomEvent("hidePreview", {composed:true}));
       this.bar.classList.add("annotation-range-div-active");
       this.bar.removeEventListener("mousemove", mouseOver);
       this._active = true;
@@ -236,15 +219,6 @@ export class SeekBar extends TatorElement {
 
   get value() {
     return this._value;
-  }
-
-  useUtcTime(timeStore) {
-    this._timeStore = timeStore;
-    this._timeMode = "utc";
-  }
-
-  useRelativeTime() {
-    this._timeMode = "relative";
   }
 
   setPair(other) {


### PR DESCRIPTION
Resolves #1908. 

Add a seek preview capability. 

- Shows the scrub feed on seek bar hover with annotation overlays.
- Added some logic to increase height during hover to make the feature less hard to use.
- In multis, only show an image if a video is focused. Only show the first focused video.

- Visual preview:
![image](https://github.com/user-attachments/assets/e8304a20-475f-4281-8334-f45316bc513f)

- Adds better accessibility to seek bar during times of use:
![image](https://github.com/user-attachments/assets/c68fa95a-2236-408e-8166-2bf0de07207c)

