### PR TITLE
Add multi support for seek preview

### DIFF
--- a/api/main/rest/_annotation_query.py
+++ b/api/main/rest/_annotation_query.py
@@ -1,4 +1,5 @@
 """ TODO: add documentation for this """
+
 import logging
 
 import json

--- a/api/main/rest/_attribute_query.py
+++ b/api/main/rest/_attribute_query.py
@@ -1,4 +1,5 @@
 """ TODO: add documentation for this """
+
 import logging
 
 from dateutil.parser import parse as dateutil_parse

--- a/api/main/rest/_attributes.py
+++ b/api/main/rest/_attributes.py
@@ -1,4 +1,5 @@
 """ TODO: add documentation for this """
+
 from typing import List
 import logging
 

--- a/api/main/rest/_base_views.py
+++ b/api/main/rest/_base_views.py
@@ -1,4 +1,5 @@
 """ TODO: add documentation for this """
+
 import traceback
 import sys
 import logging

--- a/api/main/rest/_leaf_query.py
+++ b/api/main/rest/_leaf_query.py
@@ -1,4 +1,5 @@
 """ TODO: add documentation for this """
+
 import logging
 
 import json

--- a/api/main/rest/_media_query.py
+++ b/api/main/rest/_media_query.py
@@ -1,4 +1,5 @@
 """ TODO: add documentation for this """
+
 import logging
 from urllib import parse as urllib_parse
 

--- a/api/main/rest/_media_util.py
+++ b/api/main/rest/_media_util.py
@@ -1,4 +1,5 @@
 """ TODO: add documentation for this """
+
 import logging
 import os
 import json

--- a/api/main/rest/affiliation.py
+++ b/api/main/rest/affiliation.py
@@ -22,9 +22,11 @@ def _serialize_affiliations(affiliations):
         affiliation_data[idx]["last_name"] = affiliation.user.last_name
         affiliation_data[idx]["email"] = affiliation.user.email
     affiliation_data.sort(
-        key=lambda affiliation: affiliation["last_name"].lower()
-        if affiliation["last_name"]
-        else affiliation["username"].lower()
+        key=lambda affiliation: (
+            affiliation["last_name"].lower()
+            if affiliation["last_name"]
+            else affiliation["username"].lower()
+        )
     )
     return affiliation_data
 

--- a/api/main/rest/algorithm.py
+++ b/api/main/rest/algorithm.py
@@ -1,4 +1,5 @@
 """ Algorithm REST endpoints """
+
 # pylint: disable=too-many-ancestors
 
 import logging

--- a/api/main/rest/bookmark.py
+++ b/api/main/rest/bookmark.py
@@ -1,4 +1,5 @@
 """ Bookmark REST endpoints """
+
 # pylint: disable=too-many-ancestors
 
 import logging

--- a/api/main/rest/clone_media.py
+++ b/api/main/rest/clone_media.py
@@ -71,7 +71,9 @@ class CloneMediaListAPI(BaseListView):
         # Look for destination section, if given.
         section = None
         if params.get("dest_section"):
-            sections = Section.objects.filter(project=dest, name__iexact=params["dest_section"], dtype="folder")
+            sections = Section.objects.filter(
+                project=dest, name__iexact=params["dest_section"], dtype="folder"
+            )
             if sections.count() == 0:
                 section = Section.objects.create(
                     dtype="folder",

--- a/api/main/rest/favorite.py
+++ b/api/main/rest/favorite.py
@@ -1,4 +1,5 @@
 """ Favorite REST endpoints """
+
 # pylint: disable=too-many-ancestors
 
 import logging

--- a/api/main/rest/job_cluster.py
+++ b/api/main/rest/job_cluster.py
@@ -1,4 +1,5 @@
 """ Algorithm REST endpoints """
+
 # pylint: disable=too-many-ancestors
 
 import logging

--- a/api/main/rest/media.py
+++ b/api/main/rest/media.py
@@ -271,7 +271,10 @@ def _create_media(project, params, user, use_rq=False):
         else:
             tator_user_sections = str(uuid1())
             section_obj = Section.objects.create(
-                project=project_obj, name=section, tator_user_sections=tator_user_sections, dtype="folder",
+                project=project_obj,
+                name=section,
+                tator_user_sections=tator_user_sections,
+                dtype="folder",
             )
 
     # Get the media type.

--- a/api/main/rest/upload_completion.py
+++ b/api/main/rest/upload_completion.py
@@ -11,6 +11,7 @@ from ._permissions import ProjectTransferPermission
 
 from .._permission_util import check_bucket_permissions
 
+
 class UploadCompletionAPI(BaseListView):
     """Completes a multipart upload."""
 

--- a/api/main/util.py
+++ b/api/main/util.py
@@ -1328,20 +1328,24 @@ def cull_low_used_indices(project_id, dry_run=True, population_limit=10000):
                 print(f"Deleting index for {t.name} {attr['name']}/{attr['dtype']}")
                 ts.delete_index(t, attr)
 
+
 def update_section_dtype(project_ids=None):
     projects = Project.objects.all()
     if isinstance(project_ids, list):
         projects = projects.filter(pk__in=project_ids)
     elif isinstance(project_ids, int):
         projects = projects.filter(pk=project_ids)
-    project_id_list = list(projects.values_list('id', flat=True))
-    section_list = Section.objects.filter(project__in=projects, object_search__isnull=True, related_object_search__isnull=True)
+    project_id_list = list(projects.values_list("id", flat=True))
+    section_list = Section.objects.filter(
+        project__in=projects, object_search__isnull=True, related_object_search__isnull=True
+    )
     print(f"Updating {section_list.count()} section dtypes to `folder`...")
-    section_list.update(dtype='folder')
+    section_list.update(dtype="folder")
     section_list = Section.objects.filter(project__in=projects, object_search__isnull=False)
     print(f"Updating {section_list.count()} section dtypes to `saved_search`...")
     section_list = Section.objects.filter(project__in=projects, related_object_search__isnull=False)
     print(f"Updating {section_list.count()} section dtypes to `saved_search`...")
+
 
 def update_primary_section(project_ids=None):
     projects = Project.objects.all()
@@ -1349,16 +1353,25 @@ def update_primary_section(project_ids=None):
         projects = projects.filter(pk__in=project_ids)
     elif isinstance(project_ids, int):
         projects = projects.filter(pk=project_ids)
-    project_id_list = list(projects.values_list('id', flat=True))
-    section_list = Section.objects.filter(project__in=projects, object_search__isnull=True, related_object_search__isnull=True)
+    project_id_list = list(projects.values_list("id", flat=True))
+    section_list = Section.objects.filter(
+        project__in=projects, object_search__isnull=True, related_object_search__isnull=True
+    )
     section_count = section_list.count()
     print(f"Found {section_count} sections!")
     for idx, section in enumerate(section_list.iterator()):
-        media_list = Media.objects.filter(attributes__tator_user_sections=section.tator_user_sections, primary_section__isnull=True)
+        media_list = Media.objects.filter(
+            attributes__tator_user_sections=section.tator_user_sections,
+            primary_section__isnull=True,
+        )
         count = media_list.count()
         if count == 0:
-            print(f"[{idx+1}/{section_count}] Skipping section {section.name}, no media require updates...")
+            print(
+                f"[{idx+1}/{section_count}] Skipping section {section.name}, no media require updates..."
+            )
         else:
-            print(f"[{idx+1}/{section_count}] Updating primary section for {count} media in section {section.name}...")
+            print(
+                f"[{idx+1}/{section_count}] Updating primary section for {count} media in section {section.name}..."
+            )
             media_list.update(primary_section=section)
     print("Finished updating primary section!")

--- a/api/tator_online/settings.py
+++ b/api/tator_online/settings.py
@@ -252,13 +252,15 @@ LOGGING = {
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework.authentication.TokenAuthentication",
-        "tator_online.authentication.KeycloakAuthentication",
-    )
-    if KEYCLOAK_ENABLED
-    else (
-        "rest_framework.authentication.SessionAuthentication",
-        "rest_framework.authentication.TokenAuthentication",
+        (
+            "rest_framework.authentication.TokenAuthentication",
+            "tator_online.authentication.KeycloakAuthentication",
+        )
+        if KEYCLOAK_ENABLED
+        else (
+            "rest_framework.authentication.SessionAuthentication",
+            "rest_framework.authentication.TokenAuthentication",
+        )
     ),
     "DEFAULT_RENDERER_CLASSES": (
         "main.renderers.TatorRenderer",

--- a/api/tator_online/urls.py
+++ b/api/tator_online/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import include, path
 

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -576,8 +576,22 @@ export class AnnotationMulti extends TatorElement {
       this.handleSliderChange(evt);
     });
 
-    this._slider.addEventListener("framePreview", (evt) => {
-      this.handleFramePreview(evt);
+    this._previewProcessing = false;
+    this._slider.addEventListener("framePreview", async (evt) => {
+        // debounce events here. Process the last one 500ms after the last event (as a retry)
+        clearTimeout(this._previewTimeout);
+        this._previewTimeout = setTimeout(async () => {
+          this._previewProcessing=false;
+          await this.handleFramePreview(evt);
+        }, 500);
+
+        if (this._previewProcessing == false)
+        {
+          this._previewProcessing = true;
+          await this.handleFramePreview(evt);
+          this._previewProcessing = false;
+          clearTimeout(this._previewTimeout);
+        }
     });
 
     this._slider.addEventListener("hidePreview", () => {

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -932,7 +932,7 @@ export class AnnotationMulti extends TatorElement {
   async handleFramePreview(evt) {
     let proposed_value = evt.detail.frame;
     this._preview.cancelled = false;
-    if (proposed_value > 0) {
+    if (proposed_value >= 0) {
       // Get frame preview image
       const existing = this._preview.info;
       let video = null;

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -578,20 +578,19 @@ export class AnnotationMulti extends TatorElement {
 
     this._previewProcessing = false;
     this._slider.addEventListener("framePreview", async (evt) => {
-        // debounce events here. Process the last one 500ms after the last event (as a retry)
-        clearTimeout(this._previewTimeout);
-        this._previewTimeout = setTimeout(async () => {
-          this._previewProcessing=false;
-          await this.handleFramePreview(evt);
-        }, 500);
+      // debounce events here. Process the last one 500ms after the last event (as a retry)
+      clearTimeout(this._previewTimeout);
+      this._previewTimeout = setTimeout(async () => {
+        this._previewProcessing = false;
+        await this.handleFramePreview(evt);
+      }, 500);
 
-        if (this._previewProcessing == false)
-        {
-          this._previewProcessing = true;
-          await this.handleFramePreview(evt);
-          this._previewProcessing = false;
-          clearTimeout(this._previewTimeout);
-        }
+      if (this._previewProcessing == false) {
+        this._previewProcessing = true;
+        await this.handleFramePreview(evt);
+        this._previewProcessing = false;
+        clearTimeout(this._previewTimeout);
+      }
     });
 
     this._slider.addEventListener("hidePreview", () => {
@@ -944,8 +943,7 @@ export class AnnotationMulti extends TatorElement {
         video = this._videoDivs[focus].children[0];
         useImage = true;
         bias += this._preview.img_height;
-      }
-      else if (this._videos.length <= 2) {
+      } else if (this._videos.length <= 2) {
         multiImage = true;
         video = this._videos;
         bias += this._preview.img_height;
@@ -953,16 +951,12 @@ export class AnnotationMulti extends TatorElement {
 
       // If we are already on this frame save some resources and just show the preview as-is
       if (existing.frame != proposed_value) {
-
         if (useImage) {
           this._preview.mediaInfo = video._mediaInfo;
           let frame = null;
-          try
-          {
+          try {
             frame = await video.getScrubFrame(proposed_value);
-          }
-          catch (e)
-          {
+          } catch (e) {
             console.error(`Failed to get frame ${proposed_value} ${e}`);
             return;
           }
@@ -981,15 +975,25 @@ export class AnnotationMulti extends TatorElement {
         }
         if (multiImage) {
           // Here we do both images of a multi video
-          let fake_info = {height: video[0]._mediaInfo.height, width: video[0]._mediaInfo.width*2};
+          let fake_info = {
+            height: video[0]._mediaInfo.height,
+            width: video[0]._mediaInfo.width * 2,
+          };
           this._preview.mediaInfo = fake_info;
 
-          console.info(`START: ${performance.now()}: Requesting frame ${proposed_value}`);
+          console.info(
+            `START: ${performance.now()}: Requesting frame ${proposed_value}`
+          );
           let frame0_promise = video[0].getScrubFrame(proposed_value);
           let frame1_promise = video[1].getScrubFrame(proposed_value);
           try {
-            let [frame0, frame1] = await Promise.all([frame0_promise, frame1_promise]);
-            console.info(`END: ${performance.now()}: Requesting frame ${proposed_value}`);
+            let [frame0, frame1] = await Promise.all([
+              frame0_promise,
+              frame1_promise,
+            ]);
+            console.info(
+              `END: ${performance.now()}: Requesting frame ${proposed_value}`
+            );
             if (this._preview.cancelled) {
               // We took to long and got cancelled.
               frame0.close();
@@ -997,19 +1001,22 @@ export class AnnotationMulti extends TatorElement {
               return;
             }
 
-
-
-            this._preview.image = [frame0,frame1];
+            this._preview.image = [frame0, frame1];
             frame0.close();
             frame1.close();
-          }
-          catch (e)
-          {
+          } catch (e) {
             console.error(`Failed to get frame ${proposed_value} ${e}`);
           }
 
           // Set the annotations for the multi
-          let annotations = [(video[0]._framedData.has(proposed_value) ? video[0]._framedData.get(proposed_value) : []),(video[1]._framedData.has(proposed_value) ? video[1]._framedData.get(proposed_value) : [])];
+          let annotations = [
+            video[0]._framedData.has(proposed_value)
+              ? video[0]._framedData.get(proposed_value)
+              : [],
+            video[1]._framedData.has(proposed_value)
+              ? video[1]._framedData.get(proposed_value)
+              : [],
+          ];
           this._preview.annotations = annotations;
         }
 

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -582,22 +582,22 @@ export class AnnotationMulti extends TatorElement {
 
     let processPreview = async (evt) => {
       this._pendingPreview = evt;
-        // Keep frames moving if we get dropped/interrupted
-        this._lastPreview = performance.now();
-        await this.handleFramePreview(evt);
-        this._pendingPreview = null;
+      // Keep frames moving if we get dropped/interrupted
+      this._lastPreview = performance.now();
+      await this.handleFramePreview(evt);
+      this._pendingPreview = null;
 
-        // If there is a new event to process, process it
-        while (
-          this._nextPreview &&
-          this._nextPreview.detail.frame != evt.detail.frame
-        ) {
-          this._pendingPreview = this._nextPreview;
-          this._nextPreview = null;
-          await this.handleFramePreview(this._pendingPreview);
-        }
-        this._pendingPreview = null;
-    }
+      // If there is a new event to process, process it
+      while (
+        this._nextPreview &&
+        this._nextPreview.detail.frame != evt.detail.frame
+      ) {
+        this._pendingPreview = this._nextPreview;
+        this._nextPreview = null;
+        await this.handleFramePreview(this._pendingPreview);
+      }
+      this._pendingPreview = null;
+    };
     this._slider.addEventListener("framePreview", async (evt) => {
       // Frame previews can get interrupted if we aren't keeping 30fps
       // things will look janky but we don't want to make things harder
@@ -609,9 +609,7 @@ export class AnnotationMulti extends TatorElement {
         if (delta < 33) {
           // If there is an event to process, process it
           this._nextPreview = evt;
-        }
-        else
-        {
+        } else {
           this._nextPreview = null;
           processPreview(evt);
         }
@@ -1002,22 +1000,19 @@ export class AnnotationMulti extends TatorElement {
         }
         if (multiImage) {
           // Here we do both images of a multi video
-          let fake_info = {}
-          if (video.length < 4)
-          {
+          let fake_info = {};
+          if (video.length < 4) {
             fake_info = {
               height: video[0]._mediaInfo.height,
               width: video[0]._mediaInfo.width * video.length,
             };
-          }
-          else if (video.length == 4)
-          {
+          } else if (video.length == 4) {
             fake_info = {
               height: video[0]._mediaInfo.height * 2,
               width: video[0]._mediaInfo.width * 2,
             };
           }
-          
+
           this._preview.mediaInfo = fake_info;
           let promises = [];
           for (let idx = 0; idx < video.length; idx++) {
@@ -1036,8 +1031,8 @@ export class AnnotationMulti extends TatorElement {
 
             this._preview.image = frames;
             for (let frame of frames) {
-                frame.close();
-            } 
+              frame.close();
+            }
           } catch (e) {
             console.error(`Failed to get frame ${proposed_value} ${e}`);
           }
@@ -1047,9 +1042,7 @@ export class AnnotationMulti extends TatorElement {
           for (let idx = 0; idx < video.length; idx++) {
             if (video[idx]._framedData.has(proposed_value)) {
               annotations.push(video[idx]._framedData.get(proposed_value));
-            }
-            else
-            {
+            } else {
               annotations.push([]);
             }
           }

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -660,18 +660,17 @@ export class AnnotationPlayer extends TatorElement {
       // debounce events here. Process the last one 500ms after the last event (as a retry)
       clearTimeout(this._previewTimeout);
       this._previewTimeout = setTimeout(async () => {
-        this._previewProcessing=false;
+        this._previewProcessing = false;
         await this.handleFramePreview(evt);
       }, 500);
 
-      if (this._previewProcessing == false)
-      {
+      if (this._previewProcessing == false) {
         this._previewProcessing = true;
         await this.handleFramePreview(evt);
         this._previewProcessing = false;
         clearTimeout(this._previewTimeout);
       }
-  });
+    });
 
     this._slider.addEventListener("hidePreview", () => {
       this._preview.cancelled = true; // This isn't about cancel culture

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -1052,7 +1052,7 @@ export class AnnotationPlayer extends TatorElement {
   async handleFramePreview(evt) {
     let proposed_value = evt.detail.frame;
     this._preview.cancelled = false;
-    if (proposed_value > 0) {
+    if (proposed_value >= 0) {
       // Get frame preview image
       const existing = this._preview.info;
 

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -656,9 +656,22 @@ export class AnnotationPlayer extends TatorElement {
       this.handleSliderChange(evt);
     });
 
-    this._slider.addEventListener("framePreview", (evt) => {
-      this.handleFramePreview(evt);
-    });
+    this._slider.addEventListener("framePreview", async (evt) => {
+      // debounce events here. Process the last one 500ms after the last event (as a retry)
+      clearTimeout(this._previewTimeout);
+      this._previewTimeout = setTimeout(async () => {
+        this._previewProcessing=false;
+        await this.handleFramePreview(evt);
+      }, 500);
+
+      if (this._previewProcessing == false)
+      {
+        this._previewProcessing = true;
+        await this.handleFramePreview(evt);
+        this._previewProcessing = false;
+        clearTimeout(this._previewTimeout);
+      }
+  });
 
     this._slider.addEventListener("hidePreview", () => {
       this._preview.cancelled = true; // This isn't about cancel culture

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -656,24 +656,52 @@ export class AnnotationPlayer extends TatorElement {
       this.handleSliderChange(evt);
     });
 
-    this._slider.addEventListener("framePreview", async (evt) => {
-      // debounce events here. Process the last one 500ms after the last event (as a retry)
-      clearTimeout(this._previewTimeout);
-      this._previewTimeout = setTimeout(async () => {
-        this._previewProcessing = false;
-        await this.handleFramePreview(evt);
-      }, 500);
+    this._pendingPreview = null;
+    this._nextPreview = null;
+    this._lastPreview = 0;
 
-      if (this._previewProcessing == false) {
-        this._previewProcessing = true;
+    let processPreview = async (evt) => {
+      this._pendingPreview = evt;
+        // Keep frames moving if we get dropped/interrupted
+        this._lastPreview = performance.now();
         await this.handleFramePreview(evt);
-        this._previewProcessing = false;
-        clearTimeout(this._previewTimeout);
+        this._pendingPreview = null;
+
+        // If there is a new event to process, process it
+        while (
+          this._nextPreview &&
+          this._nextPreview.detail.frame != evt.detail.frame
+        ) {
+          this._pendingPreview = this._nextPreview;
+          this._nextPreview = null;
+          await this.handleFramePreview(this._pendingPreview);
+        }
+        this._pendingPreview = null;
+    }
+    this._slider.addEventListener("framePreview", async (evt) => {
+      // Frame previews can get interrupted if we aren't keeping 30fps
+      // things will look janky but we don't want to make things harder
+      // by blocking the UI on a billion previews as someone zips by
+      if (this._pendingPreview == null) {
+        processPreview(evt);
+      } else {
+        const delta = performance.now() - this._lastPreview;
+        if (delta < 33) {
+          // If there is an event to process, process it
+          this._nextPreview = evt;
+        }
+        else
+        {
+          this._nextPreview = null;
+          processPreview(evt);
+        }
       }
     });
 
     this._slider.addEventListener("hidePreview", () => {
       this._preview.cancelled = true; // This isn't about cancel culture
+      this._pendingPreview = null;
+      this._nextPreview = null;
       this._preview.hide();
     });
 
@@ -1093,11 +1121,8 @@ export class AnnotationPlayer extends TatorElement {
           };
         }
 
-        console.info(
-          `Getting Frame Preview for ${proposed_value} existing = ${existing.frame}`
-        );
         let frame = await this._video.getScrubFrame(proposed_value);
-        console.info(`Got it!`);
+
         if (this._preview.cancelled) {
           // We took to long and got cancelled.
           frame.close();

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -662,22 +662,22 @@ export class AnnotationPlayer extends TatorElement {
 
     let processPreview = async (evt) => {
       this._pendingPreview = evt;
-        // Keep frames moving if we get dropped/interrupted
-        this._lastPreview = performance.now();
-        await this.handleFramePreview(evt);
-        this._pendingPreview = null;
+      // Keep frames moving if we get dropped/interrupted
+      this._lastPreview = performance.now();
+      await this.handleFramePreview(evt);
+      this._pendingPreview = null;
 
-        // If there is a new event to process, process it
-        while (
-          this._nextPreview &&
-          this._nextPreview.detail.frame != evt.detail.frame
-        ) {
-          this._pendingPreview = this._nextPreview;
-          this._nextPreview = null;
-          await this.handleFramePreview(this._pendingPreview);
-        }
-        this._pendingPreview = null;
-    }
+      // If there is a new event to process, process it
+      while (
+        this._nextPreview &&
+        this._nextPreview.detail.frame != evt.detail.frame
+      ) {
+        this._pendingPreview = this._nextPreview;
+        this._nextPreview = null;
+        await this.handleFramePreview(this._pendingPreview);
+      }
+      this._pendingPreview = null;
+    };
     this._slider.addEventListener("framePreview", async (evt) => {
       // Frame previews can get interrupted if we aren't keeping 30fps
       // things will look janky but we don't want to make things harder
@@ -689,9 +689,7 @@ export class AnnotationPlayer extends TatorElement {
         if (delta < 33) {
           // If there is an event to process, process it
           this._nextPreview = evt;
-        }
-        else
-        {
+        } else {
           this._nextPreview = null;
           processPreview(evt);
         }

--- a/ui/src/js/annotation/media-seek-preview.js
+++ b/ui/src/js/annotation/media-seek-preview.js
@@ -141,17 +141,15 @@ export class MediaSeekPreview extends TatorElement {
       // Less than 4 do a film strip
       if (val.length < 4) {
         for (let idx = 0; idx < val.length; idx++) {
-          let x = idx * this._img.width / val.length;
+          let x = (idx * this._img.width) / val.length;
           let width = this._img.width / val.length;
           this._ctx.drawImage(val[idx], x, 0, width, this._img.height);
         }
-      }
-      else if (val.length == 4)
-      {
+      } else if (val.length == 4) {
         // Let's do a 2x2 grid
         for (let idx = 0; idx < val.length; idx++) {
-          let x = (idx % 2) * this._img.width / 2;
-          let y = Math.floor(idx / 2) * this._img.height / 2;
+          let x = ((idx % 2) * this._img.width) / 2;
+          let y = (Math.floor(idx / 2) * this._img.height) / 2;
           let width = this._img.width / 2;
           let height = this._img.height / 2;
           this._ctx.drawImage(val[idx], x, y, width, height);
@@ -183,36 +181,48 @@ export class MediaSeekPreview extends TatorElement {
       );
     } else {
       // Put the 2 annotations stacked left to right:
-      this._drawAnnotations(
-        val[0],
-        (x) => {
-          return (x * this._img.width) / 2;
-        },
-        (y) => {
-          return y * this._img.height;
-        },
-        (width) => {
-          return (width * this._img.width) / 2;
-        },
-        (height) => {
-          return height * this._img.height;
+      if (val.length < 4) {
+        // Film strip
+        for (let idx = 0; idx < val.length; idx++) {
+          let tile_width = this._img.width / val.length;
+          this._drawAnnotations(
+            val[idx],
+            (x) => {
+              return x * tile_width + idx * tile_width;
+            },
+            (y) => {
+              return y * this._img.height;
+            },
+            (width) => {
+              return (width / val.length) * this._img.width;
+            },
+            (height) => {
+              return height * this._img.height;
+            }
+          );
         }
-      );
-      this._drawAnnotations(
-        val[1],
-        (x) => {
-          return (x * this._img.width) / 2 + this._img.width / 2;
-        },
-        (y) => {
-          return y * this._img.height;
-        },
-        (width) => {
-          return (width * this._img.width) / 2;
-        },
-        (height) => {
-          return height * this._img.height;
+      } else if (val.length == 4) {
+        // Grid
+        for (let idx = 0; idx < val.length; idx++) {
+          let tile_width = this._img.width / 2;
+          let tile_height = this._img.height / 2;
+          this._drawAnnotations(
+            val[idx],
+            (x) => {
+              return x * tile_width + (idx % 2) * tile_width;
+            },
+            (y) => {
+              return y * tile_height + Math.floor(idx / 2) * tile_height;
+            },
+            (width) => {
+              return (width / 2) * this._img.width;
+            },
+            (height) => {
+              return (height / 2) * this._img.height;
+            }
+          );
         }
-      );
+      }
     }
   }
 

--- a/ui/src/js/annotation/media-seek-preview.js
+++ b/ui/src/js/annotation/media-seek-preview.js
@@ -88,12 +88,9 @@ export class MediaSeekPreview extends TatorElement {
           this._ctx.strokeStyle = "rgb(64,224,208)";
           this._ctx.lineWidth = 3;
           this._ctx.beginPath();
-          this._ctx.moveTo(
-            xFn(localization.x),
-            yFn(localization.y)
-          );
+          this._ctx.moveTo(xFn(localization.x), yFn(localization.y));
           this._ctx.lineTo(
-            xFn((localization.x + localization.u)),
+            xFn(localization.x + localization.u),
             yFn(localization.y + localization.v)
           );
           this._ctx.stroke();
@@ -140,14 +137,17 @@ export class MediaSeekPreview extends TatorElement {
   }
 
   set image(val) {
-    if (val.constructor.name == "Array")
-    {
+    if (val.constructor.name == "Array") {
       // Put the 2 images stacked left to right:
       this._ctx.drawImage(val[0], 0, 0, this._img.width / 2, this._img.height);
-      this._ctx.drawImage(val[1], this._img.width / 2, 0, this._img.width / 2, this._img.height);
-    }
-    else
-    {
+      this._ctx.drawImage(
+        val[1],
+        this._img.width / 2,
+        0,
+        this._img.width / 2,
+        this._img.height
+      );
+    } else {
       this._ctx.drawImage(val, 0, 0, this._img.width, this._img.height);
     }
     this._img.style.display = "block";
@@ -155,15 +155,54 @@ export class MediaSeekPreview extends TatorElement {
 
   set annotations(val) {
     // Dictionary by type
-    if (val.constructor.name != "Array")
-    {
-      this._drawAnnotations(val, (x)=>{return x*this._img.width;}, (y)=>{return y*this._img.height;}, (width)=>{return width*this._img.width;}, (height)=>{return height*this._img.height;});
-    }
-    else
-    {
+    if (val.constructor.name != "Array") {
+      this._drawAnnotations(
+        val,
+        (x) => {
+          return x * this._img.width;
+        },
+        (y) => {
+          return y * this._img.height;
+        },
+        (width) => {
+          return width * this._img.width;
+        },
+        (height) => {
+          return height * this._img.height;
+        }
+      );
+    } else {
       // Put the 2 annotations stacked left to right:
-      this._drawAnnotations(val[0], (x)=>{return x*this._img.width / 2;}, (y)=>{return y*this._img.height;}, (width)=>{return width*this._img.width / 2;}, (height)=>{return height*this._img.height;});
-      this._drawAnnotations(val[1], (x)=>{return x*this._img.width / 2 + this._img.width / 2;}, (y)=>{return y*this._img.height;}, (width)=>{return width*this._img.width / 2;}, (height)=>{return height*this._img.height;});
+      this._drawAnnotations(
+        val[0],
+        (x) => {
+          return (x * this._img.width) / 2;
+        },
+        (y) => {
+          return y * this._img.height;
+        },
+        (width) => {
+          return (width * this._img.width) / 2;
+        },
+        (height) => {
+          return height * this._img.height;
+        }
+      );
+      this._drawAnnotations(
+        val[1],
+        (x) => {
+          return (x * this._img.width) / 2 + this._img.width / 2;
+        },
+        (y) => {
+          return y * this._img.height;
+        },
+        (width) => {
+          return (width * this._img.width) / 2;
+        },
+        (height) => {
+          return height * this._img.height;
+        }
+      );
     }
   }
 

--- a/ui/src/js/annotation/media-seek-preview.js
+++ b/ui/src/js/annotation/media-seek-preview.js
@@ -138,15 +138,25 @@ export class MediaSeekPreview extends TatorElement {
 
   set image(val) {
     if (val.constructor.name == "Array") {
-      // Put the 2 images stacked left to right:
-      this._ctx.drawImage(val[0], 0, 0, this._img.width / 2, this._img.height);
-      this._ctx.drawImage(
-        val[1],
-        this._img.width / 2,
-        0,
-        this._img.width / 2,
-        this._img.height
-      );
+      // Less than 4 do a film strip
+      if (val.length < 4) {
+        for (let idx = 0; idx < val.length; idx++) {
+          let x = idx * this._img.width / val.length;
+          let width = this._img.width / val.length;
+          this._ctx.drawImage(val[idx], x, 0, width, this._img.height);
+        }
+      }
+      else if (val.length == 4)
+      {
+        // Let's do a 2x2 grid
+        for (let idx = 0; idx < val.length; idx++) {
+          let x = (idx % 2) * this._img.width / 2;
+          let y = Math.floor(idx / 2) * this._img.height / 2;
+          let width = this._img.width / 2;
+          let height = this._img.height / 2;
+          this._ctx.drawImage(val[idx], x, y, width, height);
+        }
+      }
     } else {
       this._ctx.drawImage(val, 0, 0, this._img.width, this._img.height);
     }


### PR DESCRIPTION
For multis up to 2x2; support a seek preview. 

If focused, show up to 4 focused videos in a 2x2 grid. 

- Videos are rasterized to a single canvas in the seek preview to match the 'global renderer' of the full video player. Coordinate complexity is less important as its a read-only display.

- During hover operations, dropped animations are detected to ensure as close to 30fps previews occur.

*2x2 Multi with 3 videos focused:*
![image](https://github.com/user-attachments/assets/5b859055-94b2-461e-a91f-33b88a618332)

*2x2 Multi with no videos focused:*
![image](https://github.com/user-attachments/assets/8c48b477-6af6-4335-ab8e-415f8242b99f)
