### PR TITLE
Add Project Extensions Capability

### DIFF
--- a/api/main/models.py
+++ b/api/main/models.py
@@ -784,6 +784,10 @@ class Project(Model):
     """ Defines the attribute types that can be used to filter sections for this project
     """
 
+    extended_info = JSONField(default=dict, null=True, blank=True)
+    """ Extended information about the project, useful for configuration of Tator® extensions.
+    """
+
     def has_user(self, user_id):
         return self.membership_set.filter(user_id=user_id).exists()
 

--- a/api/main/rest/project.py
+++ b/api/main/rest/project.py
@@ -35,20 +35,14 @@ from .._permission_util import (
     PermissionMask,
 )
 
-from ..schema.components.project import project_properties as project_schema
+from ..schema.components.project import project as project_schema
 
 import os
 
 logger = logging.getLogger(__name__)
 
-PROJECT_PROPERTIES = list(project_schema.keys())
-PROJECT_PROPERTIES.append("thumb")
-PROJECT_PROPERTIES.append("attribute_types")
-PROJECT_PROPERTIES.append("usernames")
-PROJECT_PROPERTIES.append("id")
-PROJECT_PROPERTIES.append("num_files")
-PROJECT_PROPERTIES.append("duration")
-
+PROJECT_PROPERTIES = list(project_schema["properties"].keys())
+PROJECT_PROPERTIES.remove("permission")  # this is calculated and inserted in python-logic
 
 def _serialize_projects(projects, user_id):
     cache = TatorCache()

--- a/api/main/rest/project.py
+++ b/api/main/rest/project.py
@@ -44,6 +44,7 @@ logger = logging.getLogger(__name__)
 PROJECT_PROPERTIES = list(project_schema["properties"].keys())
 PROJECT_PROPERTIES.remove("permission")  # this is calculated and inserted in python-logic
 
+
 def _serialize_projects(projects, user_id):
     cache = TatorCache()
     ttl = 28800

--- a/api/main/schema/components/project.py
+++ b/api/main/schema/components/project.py
@@ -120,7 +120,11 @@ project = {
         },
         "extended_info": {
             "type": "object",
-            "description": "Extended information about the project.",
+            "description": "Extended information about the project. Useful Keys: "
+            + "knowledgeHref: Overrides knowledge base url when in project."
+            + "customerServiceHref: Overrides customer service url when in project."
+            + "defaultProjectPage: Overrides the default project page when in project, if a named project-page applet exists"
+            + "hideAllMedia : Hides all media option in the project-detail",
             "additionalProperties": True,
         },
     },

--- a/api/main/schema/components/project.py
+++ b/api/main/schema/components/project.py
@@ -113,5 +113,10 @@ project = {
             "type": "string",
             "description": "Permission level of user making request.",
         },
+        "attribute_types": {
+            "type": "array",
+            "description": "List of attribute types in the project (applicable to section objects)",
+            "items": {"$ref": "#/components/schemas/AttributeType"},
+        },
     },
 }

--- a/api/main/schema/components/project.py
+++ b/api/main/schema/components/project.py
@@ -118,5 +118,10 @@ project = {
             "description": "List of attribute types in the project (applicable to section objects)",
             "items": {"$ref": "#/components/schemas/AttributeType"},
         },
+        "extended_info": {
+            "type": "object",
+            "description": "Extended information about the project.",
+            "additionalProperties": True,
+        },
     },
 }

--- a/scripts/collect-static.sh
+++ b/scripts/collect-static.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 echo "Copying ui"
-docker cp ui ui:/tator_online/ui
+docker cp ui ui:/tator_online
 echo "Copying tator-js"
 docker cp scripts/packages/tator-js ui:/tator_online/scripts/packages/tator-js

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -73,6 +73,8 @@ def authenticated(request, launch_time, base_url, chrome, browser_context_args):
     context = chrome.new_context(
         **browser_context_args,
         record_video_dir=videos,
+        record_video_size={"width": 1920, "height": 1080},
+        viewport={"width": 2560, "height": 1440},
         locale="en-US",
     )
     page = context.new_page()

--- a/ui/src/js/analytics/collections/collections.js
+++ b/ui/src/js/analytics/collections/collections.js
@@ -112,6 +112,7 @@ export class AnalyticsCollections extends TatorPage {
   }
 
   _init(project) {
+    this._updateProject(project);
     this._breadcrumbs.setAttribute("project-name", project.name);
     this.loading.showSpinner();
     this.showDimmer();

--- a/ui/src/js/analytics/dashboards/dashboard-portal.js
+++ b/ui/src/js/analytics/dashboards/dashboard-portal.js
@@ -86,6 +86,7 @@ export class DashboardPortal extends TatorPage {
   }
 
   _init(project) {
+    this._updateProject(project);
     this._breadcrumbs.setAttribute("project-name", project.name);
     this._projectId = project.id;
     this._getDashboards();

--- a/ui/src/js/analytics/dashboards/dashboard.js
+++ b/ui/src/js/analytics/dashboards/dashboard.js
@@ -106,6 +106,9 @@ export class RegisteredDashboard extends TatorPage {
       "analytics-name-link",
       window.location.origin + `/${project.id}/dashboards`
     );
+    
+    // Call parent _updateProject
+    super._updateProject(project);
   }
 
   _init(dashboard) {

--- a/ui/src/js/analytics/dashboards/dashboard.js
+++ b/ui/src/js/analytics/dashboards/dashboard.js
@@ -106,7 +106,7 @@ export class RegisteredDashboard extends TatorPage {
       "analytics-name-link",
       window.location.origin + `/${project.id}/dashboards`
     );
-    
+
     // Call parent _updateProject
     super._updateProject(project);
   }

--- a/ui/src/js/analytics/export/export-page.js
+++ b/ui/src/js/analytics/export/export-page.js
@@ -1758,6 +1758,7 @@ class MainPage extends TatorPage {
 
   _updateProject(project) {
     this._breadcrumbs.setAttribute("project-name", project.name);
+    super._updateProject(project);
   }
 
   connectedCallback() {

--- a/ui/src/js/analytics/files/files-page.js
+++ b/ui/src/js/analytics/files/files-page.js
@@ -96,6 +96,7 @@ export class FilesPage extends TatorPage {
   }
 
   _init(project) {
+    this._updateProject(project);
     this._breadcrumbs.setAttribute("project-name", project.name);
     this._projectId = project.id;
     const fileTypesPromise = fetchCredentials(

--- a/ui/src/js/analytics/localizations/_extend/analytics-page.js
+++ b/ui/src/js/analytics/localizations/_extend/analytics-page.js
@@ -124,6 +124,7 @@ export class AnalyticsPage extends TatorPage {
   }
 
   async _init(project) {
+    this._updateProject(project);
     this._breadcrumbs.setAttribute("project-name", project.name);
 
     // Database interface. This should only be used by the viewModel/interface code.

--- a/ui/src/js/analytics/portal/portal.js
+++ b/ui/src/js/analytics/portal/portal.js
@@ -72,6 +72,7 @@ export class AnalyticsPortal extends TatorPage {
   }
 
   _updateProject(project) {
+    super._updateProject(project);
     this._breadcrumbs.setAttribute("project-name", project.name);
   }
 

--- a/ui/src/js/annotation/annotation-page.js
+++ b/ui/src/js/annotation/annotation-page.js
@@ -236,6 +236,9 @@ export class AnnotationPage extends TatorPage {
   _updateProject(project) {
     this.setAttribute("project-name", project.name);
     this.setAttribute("project-id", project.id);
+
+    // Call the parent's update project as well
+    super._updateProject(project);
   }
 
   _updateMedia(mediaId) {

--- a/ui/src/js/components/nav-main.js
+++ b/ui/src/js/components/nav-main.js
@@ -128,13 +128,11 @@ export class NavMain extends TatorElement {
     });
   }
 
-  set customerServiceHref(val)
-  {
+  set customerServiceHref(val) {
     this._service.href = val;
   }
 
-  set knowledgeHref(val)
-  {
+  set knowledgeHref(val) {
     this._knowledge.href = val;
   }
 

--- a/ui/src/js/components/nav-main.js
+++ b/ui/src/js/components/nav-main.js
@@ -104,6 +104,7 @@ export class NavMain extends TatorElement {
     knowledge.setAttribute("rel", "noopener noreferrer");
     knowledge.textContent = "Knowledge Base";
     headingDiv.appendChild(knowledge);
+    this._knowledge = knowledge;
 
     const service = document.createElement("a");
     service.setAttribute("class", "nav__link");
@@ -111,6 +112,7 @@ export class NavMain extends TatorElement {
     service.setAttribute("href", "mailto:info@cvisionai.com");
     service.textContent = "Customer Service";
     headingDiv.appendChild(service);
+    this._service = service;
 
     const shortcuts = document.createElement("button");
     shortcuts.setAttribute("class", "nav__link btn-clear px-0");
@@ -124,6 +126,16 @@ export class NavMain extends TatorElement {
     close.addEventListener("navClose", (evt) => {
       this.removeAttribute("is-open");
     });
+  }
+
+  set customerServiceHref(val)
+  {
+    this._service.href = val;
+  }
+
+  set knowledgeHref(val)
+  {
+    this._knowledge.href = val;
   }
 
   static get observedAttributes() {

--- a/ui/src/js/components/tator-page.js
+++ b/ui/src/js/components/tator-page.js
@@ -63,6 +63,12 @@ export class TatorPage extends TatorElement {
     }
   }
 
+  _updateProject(project)
+  {
+    this._projectInfo = project;
+    // TODO implement this
+  }
+
   _setUser(user) {
     this._header.setAttribute(
       "username",

--- a/ui/src/js/components/tator-page.js
+++ b/ui/src/js/components/tator-page.js
@@ -63,15 +63,12 @@ export class TatorPage extends TatorElement {
     }
   }
 
-  _updateProject(project)
-  {
+  _updateProject(project) {
     this._projectInfo = project;
-    if (project.extended_info.customerServiceHref)
-    {
+    if (project.extended_info.customerServiceHref) {
       this._nav.customerServiceHref = project.extended_info.customerServiceHref;
     }
-    if (project.extended_info.knowledgeHref)
-    {
+    if (project.extended_info.knowledgeHref) {
       this._nav.knowledgeHref = project.extended_info.knowledgeHref;
     }
   }

--- a/ui/src/js/components/tator-page.js
+++ b/ui/src/js/components/tator-page.js
@@ -66,7 +66,14 @@ export class TatorPage extends TatorElement {
   _updateProject(project)
   {
     this._projectInfo = project;
-    // TODO implement this
+    if (project.extended_info.customerServiceHref)
+    {
+      this._nav.customerServiceHref = project.extended_info.customerServiceHref;
+    }
+    if (project.extended_info.knowledgeHref)
+    {
+      this._nav.knowledgeHref = project.extended_info.knowledgeHref;
+    }
   }
 
   _setUser(user) {

--- a/ui/src/js/permission-settings/permission-settings.js
+++ b/ui/src/js/permission-settings/permission-settings.js
@@ -47,6 +47,7 @@ export class PermissionSettings extends TatorPage {
       (state) => state.selectedType,
       this._updateSelectedType.bind(this)
     );
+    store.subscribe((state) => state.project, this._updateProject.bind(this));
 
     // Init
     this._init();

--- a/ui/src/js/project-detail/page-applet-item.js
+++ b/ui/src/js/project-detail/page-applet-item.js
@@ -51,8 +51,7 @@ export class PageAppletItem extends TatorElement {
     });
   }
 
-  init(applet)
-  {
+  init(applet) {
     this._name.innerHTML = applet.name;
     this._applet = applet;
   }

--- a/ui/src/js/project-detail/page-applet-item.js
+++ b/ui/src/js/project-detail/page-applet-item.js
@@ -1,0 +1,80 @@
+import { TatorElement } from "../components/tator-element.js";
+
+/**
+ * Button used for the "All Media" / home in the section list
+ */
+export class PageAppletItem extends TatorElement {
+  constructor() {
+    super();
+
+    this._mainDiv = document.createElement("div");
+    this._mainDiv.setAttribute(
+      "class",
+      "rounded-2 px-1 py-1 d-flex flex-items-center clickable"
+    );
+    this._shadow.appendChild(this._mainDiv);
+
+    this._icon = document.createElement("div");
+    this._icon.setAttribute("class", "d-flex ml-3");
+    this._mainDiv.appendChild(this._icon);
+    this._icon.innerHTML = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="no-fill"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
+    `;
+
+    this._name = document.createElement("div");
+    this._name.setAttribute("class", "f2 text-gray ml-3 flex-grow");
+    this._name.innerHTML = "Page Applet";
+    this._mainDiv.appendChild(this._name);
+
+    this._mainDiv.addEventListener("mouseover", () => {
+      if (!this._active) {
+        this._mainDiv.style.backgroundColor = "#262e3d";
+        this._mainDiv.style.color = "#ffffff";
+        this._name.classList.remove("text-gray");
+        this._name.classList.add("text-white");
+      }
+    });
+
+    this._mainDiv.addEventListener("mouseout", () => {
+      if (!this._active) {
+        this._mainDiv.style.backgroundColor = "";
+        this._mainDiv.style.color = "";
+        this._name.classList.add("text-gray");
+        this._name.classList.remove("text-white");
+      }
+    });
+
+    this._mainDiv.addEventListener("click", () => {
+      this._mainDiv.blur();
+      this.setActive();
+      this.dispatchEvent(new CustomEvent("selected", { detail: { id: null } }));
+    });
+  }
+
+  init(applet)
+  {
+    this._name.innerHTML = applet.name;
+    this._applet = applet;
+  }
+
+  setActive() {
+    this._active = true;
+    this._mainDiv.style.backgroundColor = "#202543";
+    this._mainDiv.style.color = "#ffffff";
+    this._name.classList.remove("text-gray");
+    this._name.classList.add("text-white");
+    this._name.classList.add("text-semibold");
+    this._mainDiv.classList.remove("box-border");
+  }
+
+  setInactive() {
+    this._active = false;
+    this._mainDiv.style.backgroundColor = "";
+    this._mainDiv.style.color = "";
+    this._name.classList.add("text-gray");
+    this._name.classList.remove("text-white");
+    this._name.classList.remove("text-semibold");
+    this._mainDiv.classList.add("box-border");
+  }
+}
+customElements.define("page-applet-item", PageAppletItem);

--- a/ui/src/js/project-detail/project-detail.js
+++ b/ui/src/js/project-detail/project-detail.js
@@ -979,6 +979,10 @@ export class ProjectDetail extends TatorPage {
 
                 store.setState({ sections: this._sections });
 
+                const searchParams = new URLSearchParams(
+                  window.location.search
+                );
+
                 // Load page applet navigation elements
                 for (const applet of applets) {
                   if (applet.categories.includes("project-page"))
@@ -992,6 +996,11 @@ export class ProjectDetail extends TatorPage {
                     button.addEventListener("selected", () => {
                      this.selectApplet(button, applet);
                     });
+
+                    if (project.extended_info.default_project_page===applet.name && searchParams.has("section")===false)
+                    {
+                      this.selectApplet(button, applet);
+                    }
                   }
                 }
 
@@ -1066,9 +1075,6 @@ export class ProjectDetail extends TatorPage {
 
                 // Pull URL search parameters.
                 // If there are search parameters, apply them to the filterView
-                const searchParams = new URLSearchParams(
-                  window.location.search
-                );
                 if (searchParams.has("filterConditions")) {
                   this._filterURIString = searchParams.get("filterConditions");
                   this._filterConditions = JSON.parse(
@@ -1108,7 +1114,8 @@ export class ProjectDetail extends TatorPage {
                 if (searchParams.has("section")) {
                   const sectionId = Number(searchParams.get("section"));
                   this.selectSection(sectionId, initPage, initPageSize);
-                } else {
+                } else if (this._appletDiv.style.display == "none") {
+                  // Load section default if no applet is loaded already and no section was specified
                   this.selectSection(null, initPage, initPageSize);
                 }
 
@@ -1786,6 +1793,9 @@ export class ProjectDetail extends TatorPage {
   */
   selectApplet(button, applet)
   {
+    this._selectedApplet = applet;
+    this._selectedSection = null;
+    this.updateURL();
     this.makeAllInactive();
     button.setActive();
     this._pageDiv.style.display="none";
@@ -1797,6 +1807,7 @@ export class ProjectDetail extends TatorPage {
    */
   selectSection(sectionId, page, pageSize) {
 
+    this._selectedApplet = null;
     if (this._appletDiv.style.display != "none")
     {
       this._pageDiv.style.display=null;
@@ -1903,6 +1914,11 @@ export class ProjectDetail extends TatorPage {
       url.searchParams.set("section", this._selectedSection.id);
     } else {
       url.searchParams.delete("section");
+    }
+    if (this._selectedApplet !== null) {
+      url.searchParams.set("applet", this._selectedApplet.id);
+    } else {
+      url.searchParams.delete("applet");
     }
     window.history.replaceState({}, "", url.toString());
   }

--- a/ui/src/js/project-detail/project-detail.js
+++ b/ui/src/js/project-detail/project-detail.js
@@ -984,6 +984,11 @@ export class ProjectDetail extends TatorPage {
                   window.location.search
                 );
 
+                // Hide all media if specified by project extension
+                if (project.extended_info.hideAllMedia) {
+                  this._allMediaButton.style.display = "none";
+                }
+
                 // Load page applet navigation elements
                 for (const applet of applets) {
                   if (applet.categories.includes("project-page"))
@@ -998,7 +1003,7 @@ export class ProjectDetail extends TatorPage {
                      this.selectApplet(button, applet);
                     });
 
-                    if (project.extended_info.default_project_page===applet.name && searchParams.has("section")===false)
+                    if (project.extended_info.defaultProjectPage===applet.name && searchParams.has("section")===false)
                     {
                       this.selectApplet(button, applet);
                     }

--- a/ui/src/js/project-detail/project-detail.js
+++ b/ui/src/js/project-detail/project-detail.js
@@ -1837,6 +1837,7 @@ export class ProjectDetail extends TatorPage {
       }
 
       if (this._selectedSection == null) {
+        const allSearches = [...this._savedSearches.children];
         for (const search of allSearches) {
           const section = search.getSection();
           if (section.id == sectionId) {

--- a/ui/src/js/project-detail/project-detail.js
+++ b/ui/src/js/project-detail/project-detail.js
@@ -60,12 +60,17 @@ export class ProjectDetail extends TatorPage {
 
     this._mainSection = document.createElement("section");
     this._mainSection.setAttribute("class", "px-3 ml-3 flex-grow");
-    this._headerDiv = document.createElement("div");
-    this._headerDiv.setAttribute("class", "py-3 px-3 ml-3 flex-grow");
+    this._projHeaderDiv = document.createElement("div");
+    this._projHeaderDiv.setAttribute("class", "py-3 px-3 ml-3");
     this._pageDiv = document.createElement("div");
     this._pageDiv.setAttribute("class", "flex-grow");
-    this.main.appendChild(this._headerDiv);
+    this._appletDiv = document.createElement("div");
+    this._appletDiv.style.display="none";
+    this._appletIframe = document.createElement("iframe");
+    this._appletDiv.appendChild(this._appletIframe);
+    this.main.appendChild(this._projHeaderDiv);
     this.main.appendChild(this._pageDiv);
+    this.main.appendChild(this._appletDiv);
 
     this._pageDiv.appendChild(this._mainSection);
 
@@ -77,7 +82,7 @@ export class ProjectDetail extends TatorPage {
 
     const header = document.createElement("div");
     header.setAttribute("class", "main__header d-flex flex-justify-between");
-    this._headerDiv.appendChild(header);
+    this._projHeaderDiv.appendChild(header);
 
     const headerWrapperDiv = document.createElement("div");
     headerWrapperDiv.setAttribute("class", "d-flex flex-column");
@@ -982,6 +987,15 @@ export class ProjectDetail extends TatorPage {
                     button.init(applet);
                     this._pageAppletButtons.push(button);
                     this._libraryButtons.appendChild(button);
+
+                    // Handle selection
+                    button.addEventListener("selected", (evt) => {
+                      this.makeAllInactive();
+                      button.setActive();
+                      this._pageDiv.style.display="none";
+                      this._appletDiv.style.display=null;
+                      this._appletIframe.setAttribute("src", applet.html_file);
+                    });
                   }
                 }
 
@@ -1751,11 +1765,8 @@ export class ProjectDetail extends TatorPage {
     this.updateSearchesVisibility();
   }
 
-  /**
-   * @param {integer} sectionId - Tator ID of section element. If null, then All Media is assumed
-   */
-  selectSection(sectionId, page, pageSize) {
-    // Make all folders and searhes inactive
+  makeAllInactive()
+  {
     const allFolders = [...this._folders.children];
     for (const folder of allFolders) {
       folder.setInactive();
@@ -1771,6 +1782,20 @@ export class ProjectDetail extends TatorPage {
     for (const pageAppletBtn of this._pageAppletButtons) {
       pageAppletBtn.setInactive();
     }
+  }
+  /**
+   * @param {integer} sectionId - Tator ID of section element. If null, then All Media is assumed
+   */
+  selectSection(sectionId, page, pageSize) {
+
+    if (this._appletDiv.style.display != "none")
+    {
+      this._pageDiv.style.display=null;
+      this._appletDiv.style.display="none";
+    }
+    // Make all folders and searhes inactive
+    const allFolders = [...this._folders.children];
+    this.makeAllInactive();
 
     // Set the active folder or search and the mainSection portion of the page
     this._selectedSection = null;

--- a/ui/src/js/project-detail/project-detail.js
+++ b/ui/src/js/project-detail/project-detail.js
@@ -55,7 +55,7 @@ export class ProjectDetail extends TatorPage {
     //
     this.main = document.createElement("main");
     this.main.setAttribute("class", "d-flex flex-grow col-12 mr-3");
-    this.main.style.flexDirection="column";
+    this.main.style.flexDirection = "column";
     this.mainWrapper.appendChild(this.main);
 
     this._mainSection = document.createElement("section");
@@ -65,9 +65,9 @@ export class ProjectDetail extends TatorPage {
     this._pageDiv = document.createElement("div");
     this._pageDiv.setAttribute("class", "flex-grow");
     this._appletDiv = document.createElement("div");
-    this._appletDiv.style.display="none";
+    this._appletDiv.style.display = "none";
     this._appletIframe = document.createElement("iframe");
-    this._appletIframe.style.width="100%";
+    this._appletIframe.style.width = "100%";
     this._appletDiv.appendChild(this._appletIframe);
     this.main.appendChild(this._projHeaderDiv);
     this.main.appendChild(this._pageDiv);
@@ -991,8 +991,7 @@ export class ProjectDetail extends TatorPage {
 
                 // Load page applet navigation elements
                 for (const applet of applets) {
-                  if (applet.categories.includes("project-page"))
-                  {
+                  if (applet.categories.includes("project-page")) {
                     let button = document.createElement("page-applet-item");
                     button.init(applet);
                     this._pageAppletButtons.push(button);
@@ -1000,11 +999,14 @@ export class ProjectDetail extends TatorPage {
 
                     // Handle selection
                     button.addEventListener("selected", () => {
-                     this.selectApplet(button, applet);
+                      this.selectApplet(button, applet);
                     });
 
-                    if (project.extended_info.defaultProjectPage===applet.name && searchParams.has("section")===false)
-                    {
+                    if (
+                      project.extended_info.defaultProjectPage ===
+                        applet.name &&
+                      searchParams.has("section") === false
+                    ) {
                       this.selectApplet(button, applet);
                     }
                   }
@@ -1774,8 +1776,7 @@ export class ProjectDetail extends TatorPage {
     this.updateSearchesVisibility();
   }
 
-  makeAllInactive()
-  {
+  makeAllInactive() {
     const allFolders = [...this._folders.children];
     for (const folder of allFolders) {
       folder.setInactive();
@@ -1797,29 +1798,26 @@ export class ProjectDetail extends TatorPage {
   @param {button} The button that triggered the event
   @param {applet} The applet object to load in the iframe div
   */
-  selectApplet(button, applet)
-  {
+  selectApplet(button, applet) {
     this._selectedApplet = applet;
     this._selectedSection = null;
     this.updateURL();
     this.makeAllInactive();
     button.setActive();
-    this._pageDiv.style.display="none";
-    this._appletDiv.style.display=null;
+    this._pageDiv.style.display = "none";
+    this._appletDiv.style.display = null;
     const boundingRect = this._appletDiv.getBoundingClientRect();
-    this._appletIframe.style.height=`calc(100vh - ${boundingRect.top+5}px)`;
+    this._appletIframe.style.height = `calc(100vh - ${boundingRect.top + 5}px)`;
     this._appletIframe.setAttribute("src", applet.html_file);
   }
   /**
    * @param {integer} sectionId - Tator ID of section element. If null, then All Media is assumed
    */
   selectSection(sectionId, page, pageSize) {
-
     this._selectedApplet = null;
-    if (this._appletDiv.style.display != "none")
-    {
-      this._pageDiv.style.display=null;
-      this._appletDiv.style.display="none";
+    if (this._appletDiv.style.display != "none") {
+      this._pageDiv.style.display = null;
+      this._appletDiv.style.display = "none";
     }
     // Make all folders and searhes inactive
     const allFolders = [...this._folders.children];

--- a/ui/src/js/project-detail/project-detail.js
+++ b/ui/src/js/project-detail/project-detail.js
@@ -989,12 +989,8 @@ export class ProjectDetail extends TatorPage {
                     this._libraryButtons.appendChild(button);
 
                     // Handle selection
-                    button.addEventListener("selected", (evt) => {
-                      this.makeAllInactive();
-                      button.setActive();
-                      this._pageDiv.style.display="none";
-                      this._appletDiv.style.display=null;
-                      this._appletIframe.setAttribute("src", applet.html_file);
+                    button.addEventListener("selected", () => {
+                     this.selectApplet(button, applet);
                     });
                   }
                 }
@@ -1782,6 +1778,19 @@ export class ProjectDetail extends TatorPage {
     for (const pageAppletBtn of this._pageAppletButtons) {
       pageAppletBtn.setInactive();
     }
+  }
+
+  /**
+  @param {button} The button that triggered the event
+  @param {applet} The applet object to load in the iframe div
+  */
+  selectApplet(button, applet)
+  {
+    this.makeAllInactive();
+    button.setActive();
+    this._pageDiv.style.display="none";
+    this._appletDiv.style.display=null;
+    this._appletIframe.setAttribute("src", applet.html_file);
   }
   /**
    * @param {integer} sectionId - Tator ID of section element. If null, then All Media is assumed

--- a/ui/src/js/project-detail/project-detail.js
+++ b/ui/src/js/project-detail/project-detail.js
@@ -67,6 +67,7 @@ export class ProjectDetail extends TatorPage {
     this._appletDiv = document.createElement("div");
     this._appletDiv.style.display="none";
     this._appletIframe = document.createElement("iframe");
+    this._appletIframe.style.width="100%";
     this._appletDiv.appendChild(this._appletIframe);
     this.main.appendChild(this._projHeaderDiv);
     this.main.appendChild(this._pageDiv);
@@ -1800,6 +1801,8 @@ export class ProjectDetail extends TatorPage {
     button.setActive();
     this._pageDiv.style.display="none";
     this._appletDiv.style.display=null;
+    const boundingRect = this._appletDiv.getBoundingClientRect();
+    this._appletIframe.style.height=`calc(100vh - ${boundingRect.top+5}px)`;
     this._appletIframe.setAttribute("src", applet.html_file);
   }
   /**

--- a/ui/src/js/project-detail/project-detail.js
+++ b/ui/src/js/project-detail/project-detail.js
@@ -377,6 +377,7 @@ export class ProjectDetail extends TatorPage {
       (state) => state.announcements,
       this._setAnnouncements.bind(this)
     );
+    store.subscribe((state) => state.project, this._updateProject.bind(this));
 
     window.addEventListener("beforeunload", (evt) => {
       if (this._uploadDialog.hasAttribute("is-open")) {

--- a/ui/src/js/project-detail/project-detail.js
+++ b/ui/src/js/project-detail/project-detail.js
@@ -55,11 +55,19 @@ export class ProjectDetail extends TatorPage {
     //
     this.main = document.createElement("main");
     this.main.setAttribute("class", "d-flex flex-grow col-12 mr-3");
+    this.main.style.flexDirection="column";
     this.mainWrapper.appendChild(this.main);
 
     this._mainSection = document.createElement("section");
-    this._mainSection.setAttribute("class", "py-3 px-3 ml-3 flex-grow");
-    this.main.appendChild(this._mainSection);
+    this._mainSection.setAttribute("class", "px-3 ml-3 flex-grow");
+    this._headerDiv = document.createElement("div");
+    this._headerDiv.setAttribute("class", "py-3 px-3 ml-3 flex-grow");
+    this._pageDiv = document.createElement("div");
+    this._pageDiv.setAttribute("class", "flex-grow");
+    this.main.appendChild(this._headerDiv);
+    this.main.appendChild(this._pageDiv);
+
+    this._pageDiv.appendChild(this._mainSection);
 
     this.gallery = {};
     this.gallery._main = this._mainSection;
@@ -69,7 +77,7 @@ export class ProjectDetail extends TatorPage {
 
     const header = document.createElement("div");
     header.setAttribute("class", "main__header d-flex flex-justify-between");
-    div.appendChild(header);
+    this._headerDiv.appendChild(header);
 
     const headerWrapperDiv = document.createElement("div");
     headerWrapperDiv.setAttribute("class", "d-flex flex-column");

--- a/ui/src/js/project-settings/project-settings.js
+++ b/ui/src/js/project-settings/project-settings.js
@@ -153,7 +153,7 @@ export class ProjectSettings extends TatorPage {
   updateProject(newType) {
     this._breadcrumbs.setAttribute("project-name", newType.data.name);
     this.setProjectPermission(newType.data.permission);
-    this._updateProject(newType); // call parent object method
+    this._updateProject(newType.data); // call parent object method
   }
 
   /**

--- a/ui/src/js/project-settings/project-settings.js
+++ b/ui/src/js/project-settings/project-settings.js
@@ -153,6 +153,7 @@ export class ProjectSettings extends TatorPage {
   updateProject(newType) {
     this._breadcrumbs.setAttribute("project-name", newType.data.name);
     this.setProjectPermission(newType.data.permission);
+    this._updateProject(newType); // call parent object method
   }
 
   /**


### PR DESCRIPTION
Add project-level extensions to Tator UI. 

1.) Allow customer service and knowledge base URLs to be overriden on a per project basis. 
2.) Add project-page level applets that show in the project-listings Media page
3.) Allow setting a project-page as the default landing page for a project
4.) Allow disabling the "All Media" page for a project

Closes:
#1946, #1945, and #1942

![image](https://github.com/user-attachments/assets/f3f77472-746f-4655-9166-9aaddb2d359f)
