### PR TITLE
Fix schema issue with multipart uploads

### DIFF
--- a/api/main/schema/components/upload_completion.py
+++ b/api/main/schema/components/upload_completion.py
@@ -38,6 +38,7 @@ upload_completion_spec = {
             "description": "Bucket ID to use for upload. If not provided, the default. User must have permission to write to the bucket.",
             "type": "integer",
             "minimum": 1,
+            "nullable": True,
         },
     },
 }

--- a/test/_common.py
+++ b/test/_common.py
@@ -51,15 +51,30 @@ def create_media(api, project, host, token, type_id, fname, section, media_path)
 
     return media_id
 
-def upload_media_file(api,project, media_id, media_path, segments_path):
+
+def upload_media_file(
+    api, project, media_id, media_path, segments_path, chunk_size=5 * 1024 * 1024
+):
     """ Handles uploading either archival or streaming format """
     path = os.path.basename(media_path)
     filename = os.path.splitext(os.path.basename(path))[0]
-    for _, upload_info in _upload_file(api, project, media_path,
-                                        media_id=media_id, filename=f"{filename}.mp4", chunk_size=0x10000000):
+    for _, upload_info in _upload_file(
+        api,
+        project,
+        media_path,
+        media_id=media_id,
+        filename=f"{filename}.mp4",
+        chunk_size=chunk_size,
+    ):
         pass
-    for _, segment_info in _upload_file(api, project, segments_path,
-                                            media_id=media_id, filename=f"{filename}.json", chunk_size=0x10000000):
+    for _, segment_info in _upload_file(
+        api,
+        project,
+        segments_path,
+        media_id=media_id,
+        filename=f"{filename}.json",
+        chunk_size=chunk_size,
+    ):
         pass
     # Construct create video file spec.
     media_def = {**make_video_definition(media_path),
@@ -68,6 +83,7 @@ def upload_media_file(api,project, media_id, media_path, segments_path):
     response = api.create_video_file(media_id, role='streaming',
                                         video_definition=media_def)
     return response
+
 
 def get_video_path(page):
     """ Gets a page with video name set to the current test.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -597,11 +597,15 @@ def count_test(request, base_url, project, token, video_files):
     video_types = [m for m in media_types if m.dtype == "video"]
     video_type_id = video_types[0].id
 
+    # Get the file size of the mp4 file
+    file_size = os.path.getsize(count_mp4)
+
     colors=[count_mp4, count_360_mp4]
     segments=[count_segments, count_360_segments]
     media_id = create_media(api, project, base_url, token, video_type_id, "count_check.mp4", "Counts", count_mp4)
+    # Ensure it uploads in multiple chunks to verify multipart uploads
     for color,segment in zip(colors, segments):
-        upload_media_file(api, project, media_id, color, segment)
+        upload_media_file(api, project, media_id, color, segment, chunk_size=file_size / 10)
     yield media_id
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
bucket_id is optional on multipart uploads (or otherwise) but the schema did not reflect that. The transcode worker added a null bucket_id which is valid enough, probably by lieu of the generator. In this case it defaults back to the project bucket; so supplying a null bucket_id is the same as not supplying one at all.

Adds to frontend test to make use of a multipart upload to get deeper test coverage. 

Resolves #1969 

