### PR TITLE
Fixes some stability issues in video player

### DIFF
--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -2720,6 +2720,11 @@ export class AnnotationMulti extends TatorElement {
     var pausePromises = [];
     let failSafeFunction = () => {
       clearTimeout(this._failSafeTimer);
+      if (this._videoStatus != "paused") {
+        // Timer didn't get cancelled by playing, so the fail safe
+        // will be bad to execute
+        return;
+      }
       this._videoStatus = "paused";
       if (afterPause) {
         afterPause();


### PR DESCRIPTION
Resolves:

1.) On multis rapid play/pause could cause a disabled pause button, once the video start playing again.
2.) Fixes a race condition with the new 'seek preview' feature where upon play, the worker callback was set wrong. This resulted in the video not playing until a seek occurred.
3.) Catches an error condition message on init, vs. letting it be uncaught (may fix this better prior to merging, but this at least lowers log verbosity) 