### PR TITLE
Additional video fixes during load/playback cases

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -57,6 +57,9 @@ def launch_time(request):
 
 @pytest.fixture(scope='session')
 def chrome(browser_type, browser_type_launch_args):
+    args = browser_type_launch_args.get("args", [])
+    args.append("--enable-unsafe-swiftshader")
+    browser_type_launch_args["args"] = args
     yield browser_type.launch(
         **browser_type_launch_args,
         executable_path="/usr/bin/google-chrome",

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -1437,7 +1437,7 @@ export class AnnotationMulti extends TatorElement {
         this._timeStore.addChannelMedia(video_info, idx);
       }
 
-      this._videos[idx].addEventListener("playbackEnded", () => {
+      let playbackAnomalyCb = () => {
         const direction = this._videos[idx]._direction;
         this.pause(() => {
           if (direction == 1) {
@@ -1447,7 +1447,9 @@ export class AnnotationMulti extends TatorElement {
             this.goToFrame(0);
           }
         });
-      });
+      }
+      this._videos[idx].addEventListener("playbackEnded", playbackAnomalyCb);
+      this._videos[idx].addEventListener("playbackStalled", playbackAnomalyCb);
       this._videos[idx].addEventListener("canvasResized", () => {
         this._videoTimeline.redraw();
         this._entityTimeline.redraw();

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -1447,7 +1447,7 @@ export class AnnotationMulti extends TatorElement {
             this.goToFrame(0);
           }
         });
-      }
+      };
       this._videos[idx].addEventListener("playbackEnded", playbackAnomalyCb);
       this._videos[idx].addEventListener("playbackStalled", playbackAnomalyCb);
       this._videos[idx].addEventListener("canvasResized", () => {

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -1350,12 +1350,12 @@ export class AnnotationMulti extends TatorElement {
       this._videoStatus = "playing";
       this._play.removeAttribute("is-paused");
       return true;
-    }
+    };
     let global_paused = (vid_idx) => {
       global_status[vid_idx] = 0;
       this._videoStatus = "paused";
       this._play.setAttribute("is-paused", "");
-    }
+    };
 
     // Functor to normalize the progress bar
     let global_progress = new Array(video_count).fill(0);
@@ -1513,10 +1513,10 @@ export class AnnotationMulti extends TatorElement {
       });
       this._videos[idx].addEventListener("playing", () => {
         global_playing(idx);
-      })
+      });
       this._videos[idx].addEventListener("paused", () => {
         global_paused(idx);
-      })
+      });
       const smallTextStyle = {
         fontSize: "16pt",
         fontWeight: "bold",

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -737,7 +737,10 @@ export class AnnotationMulti extends TatorElement {
           this._timelineDiv.offsetHeight,
         this._videoHeightPadObject.height
       );
-      window.dispatchEvent(new Event("resize"));
+      if (this._lastVideoHeightPadHeight != this._videoHeightPadObject.height) {
+        window.dispatchEvent(new Event("resize"));
+        this._lastVideoHeightPadHeight = this._videoHeightPadObject.height;
+      }
     });
 
     this._entityTimeline.addEventListener("mouseout", (evt) => {

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -615,6 +615,18 @@ export class AnnotationPlayer extends TatorElement {
 
     this._video.addEventListener("bufferLoaded", (evt) => {
       this._slider.onBufferLoaded(evt);
+      if (
+        this._video.bufferDelayRequired() &&
+        this._video.onDemandBufferAvailable() == false
+      ) {
+        this._playInteraction.disable();
+      } else {
+        if (this._video.scrubBufferAvailable() == false) {
+          this._playInteraction.disable();
+        } else {
+          this._playInteraction.enable();
+        }
+      }
     });
 
     this._video.addEventListener("onDemandDetail", (evt) => {
@@ -1529,8 +1541,11 @@ export class AnnotationPlayer extends TatorElement {
     ) {
       this.handleNotReadyEvent();
     } else {
-      // TODO refactor this into a member function
-      this._playInteraction.enable();
+      if (this._video.scrubBufferAvailable() == false) {
+        this._playInteraction.disable();
+      } else {
+        this._playInteraction.enable();
+      }
     }
   }
   handleNotReadyEvent() {

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -746,6 +746,10 @@ export class AnnotationPlayer extends TatorElement {
       this.pause();
     });
 
+    this._video.addEventListener("playbackStalled", (evt) => {
+      this.pause();
+    });
+
     this._video.addEventListener("playbackReady", () => {
       if (this.is_paused()) {
         this._playInteraction.enable();

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -629,6 +629,16 @@ export class AnnotationPlayer extends TatorElement {
       }
     });
 
+    this._video.addEventListener("playing", () => {
+      this._play.removeAttribute("is-paused");
+      this._videoStatus = "playing";
+    });
+
+    this._video.addEventListener("paused", () => {
+      this._play.setAttribute("is-paused", "");
+      this._videoStatus = "paused";
+    });
+
     this._video.addEventListener("onDemandDetail", (evt) => {
       this._slider.onDemandLoaded(evt);
     });
@@ -700,9 +710,7 @@ export class AnnotationPlayer extends TatorElement {
       this._hideCanvasMenus();
       this._video.pause();
       this._video.rateChange(2 * this._rate);
-      if (this._video.play()) {
-        play.removeAttribute("is-paused");
-      }
+      this._video.play();
     });
 
     framePrev.addEventListener("click", () => {
@@ -851,7 +859,10 @@ export class AnnotationPlayer extends TatorElement {
         this._headerFooterPad +
         this._controls.offsetHeight +
         this._timelineDiv.offsetHeight;
-      window.dispatchEvent(new Event("resize"));
+      if (this._lastVideoHeightPadHeight != this._videoHeightPadObject.height) {
+        window.dispatchEvent(new Event("resize"));
+        this._lastVideoHeightPadHeight = this._videoHeightPadObject.height;
+      }
     });
     this._entityTimeline.addEventListener("mouseout", (evt) => {
       this.hidePreview(this);
@@ -1709,10 +1720,7 @@ export class AnnotationPlayer extends TatorElement {
     const paused = this.is_paused();
     if (paused) {
       this._video.rateChange(this._rate);
-      if (this._video.play()) {
-        this._videoStatus = "playing";
-        this._play.removeAttribute("is-paused");
-      }
+      this._video.play();
     }
   }
 
@@ -1732,10 +1740,7 @@ export class AnnotationPlayer extends TatorElement {
       //  this._rateControl.setValue(1.0, true);
       //  this._video.rateChange(this._rate);
       //}
-      if (this._video.playBackwards()) {
-        this._videoStatus = "playing";
-        this._play.removeAttribute("is-paused");
-      }
+      this._video.playBackwards();
     }
   }
 
@@ -1749,7 +1754,6 @@ export class AnnotationPlayer extends TatorElement {
     if (paused == false) {
       this._videoStatus = "paused";
       this._video.pause();
-      this._play.setAttribute("is-paused", "");
     }
     this.checkReady();
   }


### PR DESCRIPTION
Fixes:

1.) During load, the scrub buffer visual indication over-represented what regions were loaded. Re-ordered messaging such that the visual indication occurs after the buffering operation is complete vs. when the buffer is submitted to the demuxer. This resolves some cases where, especially on multis, it was possible to scrub into 'no man's land'

2.) During playback (especially >4x out of scrub), if one ran into the end of what was currently loaded, the video player did not pause like it does when you normally get to the end. This resulted in visually staying in 'playing' despite never playing again. If the user paused it usually worked out, but, because of 1 may have resulted in other issues. Now the player/multi-player will pause on playback stall events and will only play up to the point where all videos are loaded.

3.) As a by-product of 1; it was possible to get the seek cursor invalid. Upon a play attempt this could result in playing from a different location then the current visual frame. Despite fixing a known entrance into this condition, defensive programming was added to seek the scrub buffer to the desired frame prior to engaging playback vs. assuming it completed via previous seek/scrub operations.

4.) Fixes bug where if playing out of the scrub buffer if the scrub buffer is not yet available, play indication was positive. This impacted on load, when a `frame` url parameter was present; but also if seeking to scrubable regions. We now use similar logic to determine scrub playback eligibility.

5.) The video effect manager could gray out frames in the event of network timeouts. This has been resolved.

6.) Because playback command is asynchronous to actual playback, the play/pause combo button didn't work well if someone rapidly clicked it. Single-mode player doesn't change mode until the video is actually playing; multi won't change until all videos are playing. 

7.) Added logic to refresh to handle refresh-storms defensively. If a seek is already in progress, different from the display frame, refresh to that instead.

8.) Reduce the amount of refreshes, specifically caused by `graphData` events out of entity-timeline by debouncing and only causing a resize refresh if sizes have actually changed. 