### PR TITLE
Debug PR runs on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
           mkdir -p frontend-test-results;
           ssh lightsail 'mkdir -p /tmp/videos';
           sshfs -o default_permissions lightsail:/tmp/videos /tmp/videos;
-          ssh lightsail 'mkdir -p /tmp/videos && export PATH=$PATH:$HOME/.local/bin:/snap/bin && export PYTHONUNBUFFERED=1 && cd tator && for i in $(seq 1 3); do if [ -d "test-results" ]; then rm -f test-results/*; else mkdir -p test-results; fi; python3 scripts/test_support/pytest_parallel.py --num-workers 2 test --keep --base-url=http://localhost:8080 --browser=chromium --username=admin --password=admin --videos=/tmp/videos -s --junitxml=test-results/frontend-junit.xml && break || sleep 10; done;';
+          ssh lightsail 'mkdir -p /tmp/videos && export PATH=$PATH:$HOME/.local/bin:/snap/bin && export PYTHONUNBUFFERED=1 && cd tator && for i in $(seq 1 3); do if [ -d "test-results" ]; then rm -f test-results/*; else mkdir -p test-results; fi; python3 scripts/test_support/pytest_parallel.py --num-workers 1 test --keep --base-url=http://localhost:8080 --browser=chromium --username=admin --password=admin --videos=/tmp/videos -s --junitxml=test-results/frontend-junit.xml && break || sleep 10; done;';
           ssh lightsail 'test -e tator/test-results/frontend-junit.xml' && scp lightsail:tator/test-results/frontend-junit.xml frontend-test-results/ || exit 0;
           grep -q -E 'failures="[1-9]|errors="[1-9]' frontend-test-results/frontend-junit.xml && exit 1 || exit 0;
     - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,9 +212,6 @@ jobs:
         name: Install sshfs
         command: sudo -E apt-get update && sudo -E apt-get -yq --no-install-suggests --no-install-recommends install sshfs
     - run:
-        name: Sleep for 1 hour to recharge credits
-        command: sleep 3600
-    - run:
         name: Front end tests
         no_output_timeout: 30m
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,6 +212,9 @@ jobs:
         name: Install sshfs
         command: sudo -E apt-get update && sudo -E apt-get -yq --no-install-suggests --no-install-recommends install sshfs
     - run:
+        name: Sleep for 1 hour to recharge credits
+        command: sleep 3600
+    - run:
         name: Front end tests
         no_output_timeout: 30m
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
           mkdir -p frontend-test-results;
           ssh lightsail 'mkdir -p /tmp/videos';
           sshfs -o default_permissions lightsail:/tmp/videos /tmp/videos;
-          ssh lightsail 'mkdir -p /tmp/videos && export PATH=$PATH:$HOME/.local/bin:/snap/bin && export PYTHONUNBUFFERED=1 && cd tator && for i in $(seq 1 3); do if [ -d "test-results" ]; then rm -f test-results/*; else mkdir -p test-results; fi; python3 scripts/test_support/pytest_parallel.py --num-workers 1 test --keep --base-url=http://localhost:8080 --browser=chromium --username=admin --password=admin --videos=/tmp/videos -s --junitxml=test-results/frontend-junit.xml && break || sleep 10; done;';
+          ssh lightsail 'mkdir -p /tmp/videos && export PATH=$PATH:$HOME/.local/bin:/snap/bin && export PYTHONUNBUFFERED=1 && cd tator && for i in $(seq 1 3); do if [ -d "test-results" ]; then rm -f test-results/*; else mkdir -p test-results; fi; python3 scripts/test_support/pytest_parallel.py --num-workers 2 test --keep --base-url=http://localhost:8080 --browser=chromium --username=admin --password=admin --videos=/tmp/videos -s --junitxml=test-results/frontend-junit.xml && break || sleep 10; done;';
           ssh lightsail 'test -e tator/test-results/frontend-junit.xml' && scp lightsail:tator/test-results/frontend-junit.xml frontend-test-results/ || exit 0;
           grep -q -E 'failures="[1-9]|errors="[1-9]' frontend-test-results/frontend-junit.xml && exit 1 || exit 0;
     - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,7 +356,6 @@ workflows:
     - front-end-tests:
         requires:
         - rest-tests
-        - tator-py-tests
         context: cvisionai
         filters:
           tags:

--- a/scripts/lightsail.sh
+++ b/scripts/lightsail.sh
@@ -9,7 +9,7 @@ aws lightsail create-instances \
   --instance-names tator-ci-$GIT_VERSION \
   --availability-zone us-east-1a \
   --blueprint-id ubuntu_22_04 \
-  --bundle-id 2xlarge_2_0
+  --bundle-id 4xlarge_2_0
 
 # Configure SSH
 echo "Configuring ssh..."

--- a/scripts/lightsail.sh
+++ b/scripts/lightsail.sh
@@ -9,7 +9,7 @@ aws lightsail create-instances \
   --instance-names tator-ci-$GIT_VERSION \
   --availability-zone us-east-1a \
   --blueprint-id ubuntu_22_04 \
-  --bundle-id 4xlarge_2_0
+  --bundle-id 4xlarge_3_0
 
 # Configure SSH
 echo "Configuring ssh..."

--- a/scripts/test_support/pytest_parallel.py
+++ b/scripts/test_support/pytest_parallel.py
@@ -12,10 +12,14 @@ def merge_junit_reports(output_file, *input_files):
     merged_suite = TestSuite("MergedResults")
 
     for file in input_files:
-        xml = JUnitXml.fromfile(file)
-        for suite in xml:
-            for case in suite:
-                merged_suite.add_testcase(case)
+        try:
+            xml = JUnitXml.fromfile(file)
+            for suite in xml:
+                for case in suite:
+                    merged_suite.add_testcase(case)
+        except Exception as e:
+            print(f"Failed to load JUnit XML file {file}: {e}")
+
 
     merged_xml.add_testsuite(merged_suite)
     merged_xml.write(output_file)


### PR DESCRIPTION
Now that we switched the CI node to a non-bursting model, with significant CPU power, see if we can run the frontend tests + tator-py tests in parallel.

 
![image](https://github.com/user-attachments/assets/01b1a77d-a781-44a8-b3db-16551eeda7c1)
