### PR TITLE
Partial backport of section rework

### DIFF
--- a/api/main/models.py
+++ b/api/main/models.py
@@ -2170,6 +2170,14 @@ class Section(Model):
     """ Name of the section.
     """
 
+    dtype = CharField(
+        max_length=16,
+        choices=[("folder", "folder"), ("playlist", "playlist"), ("saved_search", "saved_search")],
+        default="folder",
+    )
+    """ What type of section this is.
+    """
+
     path = PathField(null=True, blank=True)
     """ Path of the section. Can only have A-Za-z0-9_- in the path name, versus any ASCII for name """
 

--- a/api/main/rest/clone_media.py
+++ b/api/main/rest/clone_media.py
@@ -40,6 +40,7 @@ class CloneMediaListAPI(BaseListView):
             new_obj.type = MediaType.objects.get(pk=dest_type)
             if section:
                 new_obj.attributes["tator_user_sections"] = section.tator_user_sections
+                new_obj.primary_section = section
             yield new_obj
 
     def _post(self, params):
@@ -70,9 +71,10 @@ class CloneMediaListAPI(BaseListView):
         # Look for destination section, if given.
         section = None
         if params.get("dest_section"):
-            sections = Section.objects.filter(project=dest, name__iexact=params["dest_section"])
+            sections = Section.objects.filter(project=dest, name__iexact=params["dest_section"], dtype="folder")
             if sections.count() == 0:
                 section = Section.objects.create(
+                    dtype="folder",
                     project=Project.objects.get(pk=dest),
                     name=params["dest_section"],
                     tator_user_sections=str(uuid1()),

--- a/api/main/rest/media.py
+++ b/api/main/rest/media.py
@@ -246,21 +246,22 @@ def _create_media(project, params, user, use_rq=False):
 
     # If section does not exist and is not an empty string, create a section.
     tator_user_sections = ""
+    section_obj = None
     if section_id:
-        section_obj = Section.objects.filter(project=project, pk=section_id)
+        section_obj = Section.objects.filter(project=project, pk=section_id, dtype="folder")
         if not section_obj.exists():
-            raise ValueError(f"Section with ID {section_id} does not exist")
+            raise ValueError(f"Folder with ID {section_id} does not exist")
         section_obj = section_obj[0]
         tator_user_sections = section_obj.tator_user_sections
     elif section:
-        section_obj = Section.objects.filter(project=project, name__iexact=section)
+        section_obj = Section.objects.filter(project=project, name__iexact=section, dtype="folder")
         if section_obj.exists():
             tator_user_sections = section_obj[0].tator_user_sections
             section_obj = section_obj[0]
         else:
             tator_user_sections = str(uuid1())
             section_obj = Section.objects.create(
-                project=project_obj, name=section, tator_user_sections=tator_user_sections
+                project=project_obj, name=section, tator_user_sections=tator_user_sections, dtype="folder",
             )
 
     # Get the media type.

--- a/api/main/rest/section.py
+++ b/api/main/rest/section.py
@@ -103,15 +103,24 @@ class SectionListAPI(BaseListView):
         attributes = params.get("attributes", {})
         explicit_listing = params.get("explicit_listing", False)
         media_list = params.get("media", [])
+        dtype = params.get("dtype", None)
 
         if Section.objects.filter(project=project, path__match=path).exists():
             raise Exception("Section with this path already exists!")
+
+        if dtype is None:
+            # Playlists can only be created if dtype is explicitly set.
+            if object_search is None and related_search is None:
+                dtype = "folder"
+            else:
+                dtype = "saved_search"
 
         project = Project.objects.get(pk=project)
 
         attrs = check_required_fields({}, project.attribute_types, {"attributes": attributes})
         section = Section.objects.create(
             project=project,
+            dtype=dtype,
             name=name,
             path=path,
             object_search=object_search,

--- a/api/main/schema/components/media_type.py
+++ b/api/main/schema/components/media_type.py
@@ -9,7 +9,7 @@ media_type_properties = {
         "default": "",
     },
     "dtype": {
-        "description": "Type of the media, image or video.",
+        "description": "Type of the media.",
         "type": "string",
         "enum": ["image", "video", "multi", "live"],
     },

--- a/api/main/schema/components/section.py
+++ b/api/main/schema/components/section.py
@@ -8,9 +8,15 @@ section_post_properties = {
         "description": "A path to represent nested sections. If not supplied, defaults to `re.sub(r'[^A-Za-z0-9_-]',path)`",
         "nullable": True,
     },
+    "dtype": {
+        "description": "Type of the section.",
+        "type": "string",
+        "enum": ["folder", "playlist", "saved_search"],
+    },
     "tator_user_sections": {
         "type": "string",
         "description": "Attribute that is applied to media to identify membership to a section.",
+        "deprecated": True,
     },
     "object_search": {"$ref": "#/components/schemas/AttributeOperationSpec"},
     "related_search": {"$ref": "#/components/schemas/AttributeOperationSpec"},
@@ -30,7 +36,8 @@ section_post_properties = {
     },
     "explicit_listing": {
         "type": "boolean",
-        "description": "Determines whether the section is explicitly made up of media IDs.",
+        "description": "Deprecated, set `dtype` to `playlist` instead. Determines whether the section is explicitly made up of media IDs.",
+        "deprecated": True,
     },
 }
 

--- a/api/main/schema/section.py
+++ b/api/main/schema/section.py
@@ -76,7 +76,7 @@ class SectionListSchema(AutoSchema):
             long_desc = ""
         elif method == "POST":
             short_desc = "Create section."
-            long_desc = "Note: In order for a section to be interpreted properly, the tator_user_sections attribute of the SectionSpec cannot be None. The front end assigns a uuid1 string for this attribute, but it is not required to follow this pattern."
+            long_desc = "The `dtype` parameter determines the behavior of the section. If `dtype` is `folder`, membership is determined by the `primary_section` field on media. If `dtype` is `playlist`, membership is determined by the `media` field in the section. If `dtype` is `saved_search`, membership is determined by `object_search`, or `related_object_search` if `object_search` is not set."
         elif method == "PATCH":
             short_desc = "Update section list."
             long_desc = dedent(

--- a/api/tator_online/authentication.py
+++ b/api/tator_online/authentication.py
@@ -2,6 +2,7 @@ import os
 
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
+import traceback
 import jwt
 from jwt.algorithms import RSAAlgorithm
 import requests
@@ -11,6 +12,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+def format_multiline(message):
+    """Formats multi-line message for single log entry"""
+    return str(message).replace("\n", " \\n ").replace("\t", "    ")
 
 class KeycloakAuthenticationMixin:
     def _get_pub_key(self):


### PR DESCRIPTION
This is a preparatory PR for `1.4.0`
* Includes the section `dtype` and sets it appropriately when sections are created
* Sets `primary_section` on media when `tator_user_sections` is set
* Does not use `primary_section` or `dtype` in queries
* Fixes missing imports in keycloak authentication