### PR TITLE
Rc/1.4.11

### DIFF
--- a/ui/src/js/annotation/entity-browser.js
+++ b/ui/src/js/annotation/entity-browser.js
@@ -253,7 +253,7 @@ export class EntityBrowser extends TatorElement {
         if (typeof obj.attributes === "string") {
           obj.attributes = JSON.parse(obj.attributes);
         }
-        const val = obj.attributes[key];
+        const val = this.getGroupNameFromAttribute(obj);
         if (groups[val] != null) {
           groups[val].push(obj);
         } else {
@@ -316,13 +316,7 @@ export class EntityBrowser extends TatorElement {
         selector.noFrames = this._noFrames;
         selector.canvas = this._canvas;
         selector.permission = this._permission;
-        var selectorName = group;
-        if (selectorName == null) {
-          selectorName = "null";
-        } else if (selectorName == "") {
-          selectorName = "(empty string)";
-        }
-        selector.setAttribute("name", selectorName);
+        selector.setAttribute("name", group);
         selector.dataType = this._dataType;
         selector.undoBuffer = this._undo;
         selector.globalDataBuffer = this._data;
@@ -537,13 +531,28 @@ export class EntityBrowser extends TatorElement {
     }
   }
 
-  selectEntity(obj) {
+  getGroupNameFromAttribute(obj) {
+    let group = obj.attributes[this._group.getValue()];
+    if (group == null) {
+      group = "(null)";
+    } else if (group == "") {
+      group = "(empty string)";
+    }
+    return group;
+  }
+
+  getGroupName(obj) {
     let group;
     if (this._group.getValue() !== "Off") {
-      group = obj.attributes[this._group.getValue()];
+      group = this.getGroupNameFromAttribute(obj);
     } else {
       group = "All " + this._title.textContent;
     }
+    return group;
+  }
+
+  selectEntity(obj) {
+    const group = this.getGroupName(obj);
     const selector = this._selectors[group];
     if (selector) {
       // Selector may not exist if element was deleted.

--- a/ui/src/js/annotation/entity-browser.js
+++ b/ui/src/js/annotation/entity-browser.js
@@ -130,7 +130,17 @@ export class EntityBrowser extends TatorElement {
       (a, b) => a.order - b.order
     );
     for (let choice of sorted) {
-      if (choice.dtype == "string" || choice.dtype == "enum") {
+      if (choice.visible == false) {
+        continue;
+      }
+      if (choice.style?.includes("not-groupable")) {
+        continue;
+      }
+      if (
+        choice.dtype == "string" ||
+        choice.dtype == "enum" ||
+        choice.dtype == "bool"
+      ) {
         choices.push({ value: choice.name });
       }
     }
@@ -306,7 +316,13 @@ export class EntityBrowser extends TatorElement {
         selector.noFrames = this._noFrames;
         selector.canvas = this._canvas;
         selector.permission = this._permission;
-        selector.setAttribute("name", group);
+        var selectorName = group;
+        if (selectorName == null) {
+          selectorName = "null";
+        } else if (selectorName == "") {
+          selectorName = "(empty string)";
+        }
+        selector.setAttribute("name", selectorName);
         selector.dataType = this._dataType;
         selector.undoBuffer = this._undo;
         selector.globalDataBuffer = this._data;

--- a/ui/src/js/annotation/entity-browser.js
+++ b/ui/src/js/annotation/entity-browser.js
@@ -235,17 +235,22 @@ export class EntityBrowser extends TatorElement {
 
   _drawControls() {
     const evt = this._evt;
-    let groups;
-    if (this._identifier && this._group.getValue() != "Off") {
+    let groups = {};
+    if (this._group.getValue() != "Off") {
       const key = this._group.getValue();
-      groups = evt.detail.data.reduce((sec, obj) => {
-        (sec[obj["attributes"][key]] = sec[obj["attributes"][key]] || []).push(
-          obj
-        );
-        return sec;
-      }, {});
+      for (let i = 0; i < evt.detail.data.length; i++) {
+        const obj = evt.detail.data[i];
+        if (typeof obj.attributes === "string") {
+          obj.attributes = JSON.parse(obj.attributes);
+        }
+        const val = obj.attributes[key];
+        if (groups[val] != null) {
+          groups[val].push(obj);
+        } else {
+          groups[val] = [obj];
+        }
+      }
     } else {
-      groups = {};
       if (evt.detail.data.length > 0) {
         const key = "All " + this._title.textContent;
         groups[key] = evt.detail.data;
@@ -518,12 +523,8 @@ export class EntityBrowser extends TatorElement {
 
   selectEntity(obj) {
     let group;
-    if (
-      this._identifier &&
-      this._group.getValue() &&
-      this._group.getValue() !== "Off"
-    ) {
-      group = obj.attributes[this._identifier.name];
+    if (this._group.getValue() !== "Off") {
+      group = obj.attributes[this._group.getValue()];
     } else {
       group = "All " + this._title.textContent;
     }


### PR DESCRIPTION
- Add improvements to database performance with fine-grained permissions enabled. 

This reduces the number of queries, even trivial ones like "EXISTS" to avoid query planning issues on deployments with many indices. Still valid to do even on deployments with less indices as less queries is always a good thing if you get the same result.