### PR TITLE
Dev/video player init issues

### DIFF
--- a/ui/src/js/annotation/annotation-common.js
+++ b/ui/src/js/annotation/annotation-common.js
@@ -205,9 +205,7 @@ export class PlayInteraction {
     if (is_paused) {
       this._parent._rewind.removeAttribute("disabled");
       this._parent._fastForward.removeAttribute("disabled");
-    }
-    else
-    {
+    } else {
       this._parent._rewind.setAttribute("disabled", "");
       this._parent._fastForward.setAttribute("disabled", "");
     }

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -1411,6 +1411,17 @@ export class AnnotationMulti extends TatorElement {
           return false;
         }
       }
+      let differentBuffer = 0;
+      for (let idx = 0; idx < this._videos.length; idx++) {
+        differentBuffer |= (this._videos[idx]._scrub_idx != this._videos[idx]._play_idx)
+      }
+      if (differentBuffer) {
+        this._rateControl.disableSpeedsAbove(RATE_CUTOFF_FOR_ON_DEMAND);
+      }
+      else
+      {
+        this._rateControl.enableAllSpeeds();
+      }
       this._videoStatus = "playing";
       this._play.removeAttribute("is-paused");
       return true;
@@ -1419,6 +1430,7 @@ export class AnnotationMulti extends TatorElement {
       global_status[vid_idx] = 0;
       this._videoStatus = "paused";
       this._play.setAttribute("is-paused", "");
+      this._rateControl.enableAllSpeeds();
     };
 
     // Functor to normalize the progress bar

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -1413,7 +1413,7 @@ export class AnnotationMulti extends TatorElement {
       }
       let differentBuffer = 0;
       for (let idx = 0; idx < this._videos.length; idx++) {
-        differentBuffer |= (this._videos[idx]._scrub_idx != this._videos[idx]._play_idx) && (this._videos[idx]._play_idx == this._videos[idx]._active_idx)
+        differentBuffer |= (this._videos[idx]._scrub_idx != this._videos[idx]._play_idx) && (this._videos[idx]._scrub_idx != this._videos[idx]._active_idx)
       }
       if (differentBuffer) {
         this._rateControl.disableSpeedsAbove(RATE_CUTOFF_FOR_ON_DEMAND);

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -1894,6 +1894,17 @@ export class AnnotationMulti extends TatorElement {
     const scrubInfo = this._videos[idx].getQuality("scrub");
     const playInfo = this._videos[idx].nearestQuality(this._quality);
 
+    let params = new URLSearchParams(document.location.search.substring(1));
+    params.set("playQuality", playInfo.quality);
+    params.set("scrubQuality", scrubInfo.quality);
+    params.set("seekQuality", seekInfo.quality);
+    const path = document.location.pathname;
+    const searchArgs = params.toString();
+    var newUrl = path;
+    newUrl += "?" + searchArgs;
+
+    window.history.replaceState('quality', "playQuality", newUrl);
+
     this.dispatchEvent(
       new CustomEvent("defaultVideoSettings", {
         composed: true,

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -1568,7 +1568,6 @@ export class AnnotationMulti extends TatorElement {
         });
       };
       this._videos[idx].addEventListener("playbackEnded", playbackAnomalyCb);
-      this._videos[idx].addEventListener("playbackStalled", playbackAnomalyCb);
       this._videos[idx].addEventListener("canvasResized", () => {
         this._videoTimeline.redraw();
         this._entityTimeline.redraw();

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -1530,6 +1530,9 @@ export class AnnotationMulti extends TatorElement {
         });
         prime.addEventListener("frameChange", (evt) => {
           const frame = evt.detail.frame;
+          if (frame == undefined || frame == null) {
+            return;
+          }
           this._slider.value = frame;
           const time = frameToTime(frame, this._fps[this._longest_idx]);
           this._currentTimeText.textContent = time;

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -655,9 +655,8 @@ export class AnnotationMulti extends TatorElement {
     });
 
     fastForward.addEventListener("click", () => {
-      const paused = this.is_paused()
-      if (paused == false)
-      {
+      const paused = this.is_paused();
+      if (paused == false) {
         return;
       }
       this._hideCanvasMenus();
@@ -1413,13 +1412,13 @@ export class AnnotationMulti extends TatorElement {
       }
       let differentBuffer = 0;
       for (let idx = 0; idx < this._videos.length; idx++) {
-        differentBuffer |= (this._videos[idx]._scrub_idx != this._videos[idx]._play_idx) && (this._videos[idx]._scrub_idx != this._videos[idx]._active_idx)
+        differentBuffer |=
+          this._videos[idx]._scrub_idx != this._videos[idx]._play_idx &&
+          this._videos[idx]._scrub_idx != this._videos[idx]._active_idx;
       }
       if (differentBuffer) {
         this._rateControl.disableSpeedsAbove(RATE_CUTOFF_FOR_ON_DEMAND);
-      }
-      else
-      {
+      } else {
         this._rateControl.enableAllSpeeds();
       }
       this._videoStatus = "playing";
@@ -1917,7 +1916,7 @@ export class AnnotationMulti extends TatorElement {
     var newUrl = path;
     newUrl += "?" + searchArgs;
 
-    window.history.replaceState('quality', "playQuality", newUrl);
+    window.history.replaceState("quality", "playQuality", newUrl);
 
     this.dispatchEvent(
       new CustomEvent("defaultVideoSettings", {
@@ -2817,9 +2816,8 @@ export class AnnotationMulti extends TatorElement {
   }
 
   playBackwards() {
-    const paused = this.is_paused()
-    if (paused == false)
-    {
+    const paused = this.is_paused();
+    if (paused == false) {
       return;
     }
     let playing = false;

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -1413,7 +1413,7 @@ export class AnnotationMulti extends TatorElement {
       }
       let differentBuffer = 0;
       for (let idx = 0; idx < this._videos.length; idx++) {
-        differentBuffer |= (this._videos[idx]._scrub_idx != this._videos[idx]._play_idx)
+        differentBuffer |= (this._videos[idx]._scrub_idx != this._videos[idx]._play_idx) && (this._videos[idx]._play_idx == this._videos[idx]._active_idx)
       }
       if (differentBuffer) {
         this._rateControl.disableSpeedsAbove(RATE_CUTOFF_FOR_ON_DEMAND);

--- a/ui/src/js/annotation/annotation-multi.js
+++ b/ui/src/js/annotation/annotation-multi.js
@@ -2754,6 +2754,8 @@ export class AnnotationMulti extends TatorElement {
   play() {
     this._ratesAvailable = this.computeRatesAvailable();
     clearTimeout(this._failSafeTimer);
+    this._rateControl.disableSpeedsAbove(0);
+
     if (this._rate > RATE_CUTOFF_FOR_ON_DEMAND) {
       let playing = false;
       // Check to see if the video player can play at this rate
@@ -2862,6 +2864,7 @@ export class AnnotationMulti extends TatorElement {
     this._ratesAvailable = null;
     this.dispatchEvent(new Event("paused", { composed: true }));
     this.enableRateChange();
+    this._rateControl.enableAllSpeeds();
     //this._rateControl.setValue(this._rate);
     this.checkReady(); // Verify ready state, this will gray out elements if buffering is required.
 

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -648,7 +648,7 @@ export class AnnotationPlayer extends TatorElement {
       this._play.removeAttribute("is-paused");
       this._videoStatus = "playing";
       this._playInteraction.enable(this.is_paused());
-      if (this._video._play_idx != this._video._scrubIdx && this._video._play_idx  == this._video._active_idx)
+      if (this._video._play_idx != this._video._scrubIdx && this._video._scrub_idx  != this._video._active_idx)
       {
         this._rateControl.disableSpeedsAbove(RATE_CUTOFF_FOR_ON_DEMAND);
       }

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -647,13 +647,12 @@ export class AnnotationPlayer extends TatorElement {
     this._video.addEventListener("playing", () => {
       this._play.removeAttribute("is-paused");
       this._videoStatus = "playing";
-      this._playInteraction.enable(this.is_paused());
-      if (this._video._play_idx != this._video._scrubIdx && this._video._scrub_idx  != this._video._active_idx)
-      {
+      if (
+        this._video._play_idx != this._video._scrubIdx &&
+        this._video._scrub_idx != this._video._active_idx
+      ) {
         this._rateControl.disableSpeedsAbove(RATE_CUTOFF_FOR_ON_DEMAND);
-      }
-      else
-      {
+      } else {
         this._rateControl.enableAllSpeeds();
       }
       this._playInteraction.enable(this.is_paused());
@@ -1409,7 +1408,7 @@ export class AnnotationPlayer extends TatorElement {
         var newUrl = path;
         newUrl += "?" + searchArgs;
 
-        window.history.replaceState('quality', "playQuality", newUrl);
+        window.history.replaceState("quality", "playQuality", newUrl);
 
         this.dispatchEvent(
           new CustomEvent("defaultVideoSettings", {

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -772,7 +772,9 @@ export class AnnotationPlayer extends TatorElement {
 
     this._video.addEventListener("frameChange", (evt) => {
       const frame = evt.detail.frame;
-
+      if (frame == undefined || frame == null) {
+        return;
+      }
       const time = frameToTime(frame, this._mediaInfo.fps);
       this._currentTimeText.textContent = time;
       this._currentFrameText.textContent = frame;

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -648,7 +648,7 @@ export class AnnotationPlayer extends TatorElement {
       this._play.removeAttribute("is-paused");
       this._videoStatus = "playing";
       this._playInteraction.enable(this.is_paused());
-      if (this._video._play_idx != this._video._scrubIdx)
+      if (this._video._play_idx != this._video._scrubIdx && this._video._play_idx  == this._video._active_idx)
       {
         this._rateControl.disableSpeedsAbove(RATE_CUTOFF_FOR_ON_DEMAND);
       }

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -1744,6 +1744,8 @@ export class AnnotationPlayer extends TatorElement {
         return;
       }
     }
+    this._rateControl.disableSpeedsAbove(0);
+
     this._ratesAvailable = this._video.playbackRatesAvailable();
 
     if (
@@ -1794,6 +1796,7 @@ export class AnnotationPlayer extends TatorElement {
     this._fastForward.removeAttribute("disabled");
     this._rewind.removeAttribute("disabled");
     this.enableRateChange();
+    this._rateControl.enableAllSpeeds();
 
     const paused = this.is_paused();
     if (paused == false) {

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -656,6 +656,7 @@ export class AnnotationPlayer extends TatorElement {
       {
         this._rateControl.enableAllSpeeds();
       }
+      this._playInteraction.enable(this.is_paused());
     });
 
     this._video.addEventListener("paused", () => {

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -1418,6 +1418,18 @@ export class AnnotationPlayer extends TatorElement {
           })
         );
 
+        // Set qualities now that video is loaded
+        if (val.media_files && "streaming" in val.media_files) {
+          let quality_list = [];
+          for (let media_file of val.media_files["streaming"]) {
+            quality_list.push(media_file.resolution[0]);
+          }
+          this._qualityControl.resolutions = quality_list;
+          this._qualityControl.show();
+        } else {
+          this._qualityControl.hide();
+        }
+
         this.dispatchEvent(
           new Event("canvasReady", {
             composed: true,
@@ -1440,16 +1452,6 @@ export class AnnotationPlayer extends TatorElement {
       this._volume_control.style.display = "none";
     }
     this._volume_control.volume = this.mediaType["default_volume"];
-    if (val.media_files && "streaming" in val.media_files) {
-      let quality_list = [];
-      for (let media_file of val.media_files["streaming"]) {
-        quality_list.push(media_file.resolution[0]);
-      }
-      this._qualityControl.resolutions = quality_list;
-      this._qualityControl.show();
-    } else {
-      this._qualityControl.hide();
-    }
   }
 
   set annotationData(val) {

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -648,11 +648,20 @@ export class AnnotationPlayer extends TatorElement {
       this._play.removeAttribute("is-paused");
       this._videoStatus = "playing";
       this._playInteraction.enable(this.is_paused());
+      if (this._video._play_idx != this._video._scrubIdx)
+      {
+        this._rateControl.disableSpeedsAbove(RATE_CUTOFF_FOR_ON_DEMAND);
+      }
+      else
+      {
+        this._rateControl.enableAllSpeeds();
+      }
     });
 
     this._video.addEventListener("paused", () => {
       this._play.setAttribute("is-paused", "");
       this._videoStatus = "paused";
+      this._rateControl.enableAllSpeeds();
     });
 
     this._video.addEventListener("onDemandDetail", (evt) => {

--- a/ui/src/js/annotation/annotation-player.js
+++ b/ui/src/js/annotation/annotation-player.js
@@ -1388,6 +1388,17 @@ export class AnnotationPlayer extends TatorElement {
 
         this._setToPlayMode();
 
+        let params = new URLSearchParams(document.location.search.substring(1));
+        params.set("playQuality", playInfo.quality);
+        params.set("scrubQuality", scrubInfo.quality);
+        params.set("seekQuality", seekInfo.quality);
+        const path = document.location.pathname;
+        const searchArgs = params.toString();
+        var newUrl = path;
+        newUrl += "?" + searchArgs;
+
+        window.history.replaceState('quality', "playQuality", newUrl);
+
         this.dispatchEvent(
           new CustomEvent("defaultVideoSettings", {
             composed: true,

--- a/ui/src/js/annotation/rate-control.js
+++ b/ui/src/js/annotation/rate-control.js
@@ -124,8 +124,7 @@ export class RateControl extends TatorElement {
     this._select.selectedIndex = oldIdx;
   }
 
-  disableSpeedsAbove(max)
-  {
+  disableSpeedsAbove(max) {
     for (let idx = 0; idx < this._select.options.length; idx++) {
       const rate = this._select.options[idx].value;
       if (rate > max) {
@@ -135,7 +134,6 @@ export class RateControl extends TatorElement {
           "title",
           `Dynamically changing to ${rate}x is disabled during network playback.`
         );
-
       } else {
         this._select.options[idx].removeAttribute("disabled");
         this._select.options[idx].removeAttribute("title");
@@ -143,11 +141,10 @@ export class RateControl extends TatorElement {
     }
   }
 
-  enableAllSpeeds()
-  {
+  enableAllSpeeds() {
     for (let idx = 0; idx < this._select.options.length; idx++) {
-        this._select.options[idx].removeAttribute("disabled");
-        this._select.options[idx].removeAttribute("title");
+      this._select.options[idx].removeAttribute("disabled");
+      this._select.options[idx].removeAttribute("title");
     }
   }
 

--- a/ui/src/js/annotation/rate-control.js
+++ b/ui/src/js/annotation/rate-control.js
@@ -124,6 +124,33 @@ export class RateControl extends TatorElement {
     this._select.selectedIndex = oldIdx;
   }
 
+  disableSpeedsAbove(max)
+  {
+    for (let idx = 0; idx < this._select.options.length; idx++) {
+      const rate = this._select.options[idx].value;
+      if (rate > max) {
+        this._select.options[idx].setAttribute("disabled", "");
+        // Set a tool-tip
+        this._select.options[idx].setAttribute(
+          "title",
+          `Dynamically changing to ${rate}x is disabled during network playback.`
+        );
+
+      } else {
+        this._select.options[idx].removeAttribute("disabled");
+        this._select.options[idx].removeAttribute("title");
+      }
+    }
+  }
+
+  enableAllSpeeds()
+  {
+    for (let idx = 0; idx < this._select.options.length; idx++) {
+        this._select.options[idx].removeAttribute("disabled");
+        this._select.options[idx].removeAttribute("title");
+    }
+  }
+
   getIdx() {
     return this._select.selectedIndex;
   }


### PR DESCRIPTION
Fixes a few video initialization and lockout related issues (forward port from 1.4.17):

- Adds UI lockout to rate changes when they are invalid
- Changes stall logic to be more like a plane. This allows for more jitter during playback which may be helpful on some stressful decoding corner cases. It will result in less frames per second, but not alert the user anything is awry until no frames are present for over 2 seconds.
- The dynamic rate change logic is slightly better to change rates 'faster', removing frames that are pre-loaded ahead of the current disp frame which would be at a different rate then the new rate.
- Removed callback that forced multi-videos to jump to the end or beginning on any kind of stall error.
- Resolves load issue where 720p was added to the URL param to cause prev/next videos to be loaded with more aggressive settings then the current one, if the default multi resolution was 360. Now all qualities are posted to the URL param.

